### PR TITLE
– Added glyphs, brm_shortE  (U+11071) , brm_shortO (U+11072)

### DIFF
--- a/sources/NotoSansBrahmi.glyphs
+++ b/sources/NotoSansBrahmi.glyphs
@@ -1,11 +1,26 @@
 {
-.appVersion = "3180";
+.appVersion = "3151";
 DisplayStrings = (
-"/brm_GA/brm_vowelAA/space/brm_vowelBHATTIPROLUAA"
+"/candrabindu.alt/space/brm_OldTamilVirama/brm_OldTamilVirama.alt/space/space/space/space/brm_KA/brm_PA/brm_YA/SA/space/brm_NYA/brm_RRA/brm_RRAVirama/space/brm_NGA/brm_TTA/brm_NNA/space/uni25CC/brm_OldTamilVirama/space/brm_RA/brm_OldTamilVirama/space/brm_CA/brm_OldTamilVirama/space/brm_MA/brm_OldTamilVirama/space/brm_LA/brm_OldTamilVirama/space/brm_VA/brm_OldTamilVirama/space/brm_LLLA/brm_OldTamilVirama/space/brm_NNNA/brm_OldTamilVirama/space/brm_SHA/brm_OldTamilVirama/space/brm_DHA/brm_OldTamilVirama/space/brm_TA/brm_OldTamilVirama/space/brm_NA/brm_OldTamilVirama",
+"/anusvara/brm_vowelAA/brm_vowelBHATTIPROLUAA/brm_vowelI/brm_vowelII/brm_vowelU/brm_vowelUU/brm_VOCALIC_R/brm_VOCALIC_RR/brm_VOCALIC_L/brm_VOCALIC_LL/brm_vowelEE/brm_vowelAI/brm_vowelOO/brm_vowelAU/brm_virama/brm_OldTamilVirama/candrabindu.alt/brm_vowelU.alt/brm_vowelUU.alt/brm_vowelUU.alt2/brm_VOCALIC_R.alt/brm_VOCALIC_R.alt2/brm_VOCALIC_RR.alt/brm_VOCALIC_RR.alt2/brm_VOCALIC_RR.alt3/vowelU_vert/vowelUU_vert/brm_OldTamilVirama.alt/space/space/space/brm_KA/brm_NGA/brm_CA/brm_NYA/brm_TTA/brm_NNA/brm_TA/brm_DHA/brm_NA/brm_PA/brm_MA/brm_YA/brm_RA/brm_LA/brm_VA/brm_SHA/SA/brm_LLLA/brm_RRA/brm_NNNA",
+"/brm_NYO/brm_NYAshortO/brm_DHO/brm_DHAshortO/brm_MO/brm_MAshortO/brm_LLLO/brm_LLLAshortO/brm_RRO/brm_RRAshortO/brm_NNNO/brm_NNNAshortO",
+"/brm_vowelEE/space/space/space/brm_KA/brm_NGA/brm_CA/brm_NYA/brm_TTA/brm_NNA/brm_TA/brm_DHA/brm_NA/brm_PA/brm_MA/brm_YA/brm_RA/brm_LA/brm_VA/brm_SHA/SA/brm_LLLA/brm_RRA/brm_NNNA/brm_OldTamilLLA",
+"/brm_KA/brm_OldTamilVirama/brm_BA/brm_RA/brm_OldTamilVirama/brm_TA/brm_OldTamilVirama/brm_DHA/brm_DHA/brm_OldTamilVirama/brm_NA/brm_DHA/brm_OldTamilVirama/brm_VA/brm_OldTamilVirama/brm_SHA/brm_OldTamilVirama/brm_LLLA/brm_OldTamilVirama/uni25CC/brm_OldTamilVirama.alt",
+"/brm_OldTamilVirama.alt",
+"/brm_vowelShortE",
+"/brm_TUU",
+"/brm_TA",
+"/brm_CUU",
+"/brm_CA",
+"/brm_NUU",
+"/brm_NA",
+"/brm_YA",
+"",
+"/brm_vowelU/space/brm_RRA"
 );
 classes = (
 {
-code = "SA brm_AU brm_BHA brm_CHA brm_DA brm_DDHA brm_GHA brm_HA brm_KA brm_LLA brm_NA brm_NGA brm_NNA brm_NYA brm_O brm_PA brm_PHA brm_R brm_RR brm_SSA brm_TA brm_TTA brm_U brm_UU brm_VA brm_YA";
+code = "SA brm_AU brm_BHA brm_CHA brm_DA brm_DDHA brm_GHA brm_HA brm_KA brm_OldTamilLLA brm_NA brm_NGA brm_NNA brm_NYA brm_O brm_shortO brm_PA brm_PHA brm_R brm_RR brm_SSA brm_TA brm_TTA brm_U brm_UU brm_VA brm_YA\012";
 name = class1;
 },
 {
@@ -13,55 +28,59 @@ code = "brm_CA brm_CHA brm_DDHA brm_GHA brm_HA brm_JA brm_MA brm_PA brm_PHA brm_
 name = class2;
 },
 {
-code = "brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU";
+code = "#glyphs that do not have an indented space at the top left unlike KA, CA, YA, LA, LLA, BHA, SA, NA, etc.\012brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU brm_LLLA brm_KA brm_CA brm_TA brm_NA brm_YA SA\012";
 name = class4;
 },
 {
-code = "brm_BHA brm_CA brm_DDA brm_DDHA brm_JHA brm_KHA brm_LA brm_LLLA brm_MA brm_NNNA brm_RA brm_RRA brm_THA brm_TTA brm_TTHA brm_VA";
+code = "#glyphs that combine with vowelI and vowelII such that it sticks out on the top right\012brm_BHA brm_CA brm_DDA brm_LLA brm_DDHA brm_JHA brm_KHA brm_LA brm_LLLA brm_MA brm_NNNA brm_RA brm_RRA brm_THA brm_TTA brm_TTHA brm_VA brm_NA\012";
 name = class5;
 },
 {
-code = "brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU";
+code = "#same as class4 minus BHAU\012brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU brm_LLLA brm_KA brm_CA brm_TA brm_NA brm_YA SA\012";
 name = class6;
 },
 {
-code = "brm_BA brm_BHA brm_CA brm_DDA brm_DDHA brm_JHA brm_KHA brm_LA brm_LLLA brm_MA brm_NNNA brm_RA brm_RRA brm_THA brm_TTA brm_TTHA brm_VA";
+code = "#glyphs that combine with vowelAA such that it sticks out on the top right\012brm_BA brm_BHA brm_CA brm_DDA brm_LLA brm_DDHA brm_JHA brm_KHA brm_LA brm_LLLA brm_MA brm_NNNA brm_RA brm_RRA brm_THA brm_TTHA brm_VA\012";
 name = class9;
 },
 {
-code = "brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU";
+code = "#same as class6 plus BHA, BHAU, and TA\012brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU brm_OldTamilLLA brm_CA brm_NA brm_YA brm_LA brm_LLLA SA\012";
 name = class10;
 },
 {
-code = "SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_LLA brm_LLLA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU";
+code = "SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_OldTamilLLA brm_LLLA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU\012";
 name = class15;
 },
 {
-code = "SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_LLA brm_LLLA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU";
+code = "SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_OldTamilLLA brm_LLLA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU\012";
 name = class18;
 },
 {
-code = "SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_LLA brm_LLLA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THU brm_THUU brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU";
+code = "SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_OldTamilLLA brm_LLLA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THU brm_THUU brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU\012";
 name = class21;
 },
 {
-code = "brm_DDA brm_HA brm_JA brm_JHA brm_LLLA brm_MA brm_NNA brm_TTA";
+code = "#characters that don't need added width when combining with matraU and matraUU\012brm_DDA brm_LLA brm_HA brm_JA brm_JHA brm_LLLA brm_MA brm_NNA brm_TTA\012";
 name = class25;
 },
 {
-code = "brm_AI brm_AU brm_BA brm_CHA brm_DA brm_DDA brm_DDHA brm_DHA brm_GA brm_GHA brm_HA brm_JA brm_JHA brm_JNYA brm_LLLA brm_MA brm_NA brm_NGA brm_NNA brm_NNNA brm_NYA brm_O brm_PA brm_PHA brm_RA brm_RRA brm_SHA brm_SSA brm_TA brm_TTA brm_VA";
+code = "#same as 25 minus brm_TTA\012brm_DDA brm_LLA brm_HA brm_JA brm_JHA brm_LLLA brm_MA brm_NNA";
+name = class26;
+},
+{
+code = "brm_AI brm_AU brm_BA brm_CHA brm_DA brm_DDA brm_LLA brm_DDHA brm_DHA brm_shortE brm_GA brm_GHA brm_HA brm_JA brm_JHA brm_JNYA brm_LLLA brm_MA brm_NA brm_NGA brm_NNA brm_NNNA brm_NYA brm_O brm_shortO brm_PA brm_PHA brm_RA brm_RRA brm_RRAVirama brm_SHA brm_SSA brm_TA brm_TTA brm_VA\012";
 name = class34;
 },
 {
-code = "SA brm_BA brm_BHA brm_CA brm_CHA brm_DA brm_DDA brm_DDHA brm_DHA brm_GA brm_GHA brm_HA brm_JA brm_JHA brm_KA brm_KHA brm_LA brm_LLA brm_LLLA brm_MA brm_NA brm_NGA brm_NNA brm_NNNA brm_NYA brm_PA brm_PHA brm_RA brm_RRA brm_SHA brm_SSA brm_TA brm_THA brm_TTA brm_TTHA brm_VA brm_YA";
+code = "SA brm_BA brm_BHA brm_CA brm_CHA brm_DA brm_DDA brm_LLA brm_DDHA brm_DHA brm_shortE brm_GA brm_GHA brm_HA brm_JA brm_JHA brm_KA brm_KHA brm_LA brm_OldTamilLLA brm_LLLA brm_MA brm_NA brm_NGA brm_NNA brm_NNNA brm_NYA brm_PA brm_PHA brm_RA brm_RRA brm_RRAVirama brm_SHA brm_SSA brm_TA brm_THA brm_TTA brm_TTHA brm_VA brm_YA brm_OldTamilVirama brm_OldTamilVirama.alt brm_vowelAA brm_vowelI brm_vowelII brm_vowelU brm_vowelUU brm_vowelU.alt brm_vowelUU.alt brm_vowelUU.alt2 brm_vowelShortE brm_vowelEE brm_vowelShortO brm_vowelOO brm_vowelAI brm_vowelAU\012";
 name = class35;
 },
 {
-code = "brm_A brm_AA brm_AI brm_AU brm_E brm_I brm_II brm_L brm_LL brm_O brm_R brm_RR brm_U brm_UU";
+code = "brm_A brm_AA brm_AI brm_AU brm_E brm_shortE brm_I brm_II brm_L brm_LL brm_O brm_shortO brm_R brm_RR brm_U brm_UU\012";
 name = class37;
 },
 {
-code = "brm_BAU brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DAU brm_DDHU brm_DDHUU brm_DHAU brm_DHO brm_DHU brm_DHUU brm_GHU brm_GHUU brm_HU brm_HUU brm_JAA brm_JAU brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KSSA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MAU brm_MO brm_MU brm_MUU brm_NGU brm_NGUU brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYAU brm_NYO brm_PHU brm_PHUU brm_PU brm_PUU brm_RRAU brm_RRO brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_VU brm_VUU brm_YU brm_YUU";
+code = "brm_BAU brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DAU brm_DDHU brm_DDHUU brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_GHU brm_GHUU brm_HU brm_HUU brm_JAA brm_JAU brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KSSA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NGU brm_NGUU brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYAU brm_NYO brm_NYAshortO brm_PHU brm_PHUU brm_PU brm_PUU brm_RRAU brm_RRO brm_RRAshortO brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_VU brm_VUU brm_YU brm_YUU\012";
 name = class39;
 },
 {
@@ -69,16 +88,24 @@ code = "brm_VOCALIC_L brm_VOCALIC_LL brm_VOCALIC_R brm_VOCALIC_R.alt brm_VOCALIC
 name = class41;
 },
 {
-code = "brm_AI brm_AU brm_BA brm_BHA brm_CA brm_CHA brm_DA brm_DDA brm_DDHA brm_DHA brm_GA brm_GHA brm_HA brm_JA brm_JHA brm_LLLA brm_MA brm_NA brm_NGA brm_NNA brm_NNNA brm_NYA brm_O brm_PA brm_PHA brm_RA brm_RRA brm_SHA brm_SSA brm_TA brm_TTA brm_VA brm_YA";
+code = "brm_AI brm_AU brm_BA brm_BHA brm_CA brm_CHA brm_DA brm_DDA brm_LLA brm_DDHA brm_DHA brm_shortE brm_GA brm_GHA brm_HA brm_JA brm_JHA brm_LLLA brm_MA brm_NA brm_NGA brm_NNA brm_NNNA brm_NYA brm_O brm_shortO brm_PA brm_PHA brm_RA brm_RRA brm_RRAVirama brm_SHA brm_SSA brm_TA brm_TTA brm_VA brm_YA\012";
 name = class42;
 },
 {
-code = "brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU";
+code = "brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHAU brm_BO brm_BU brm_BUU brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KHA brm_KSSA brm_L brm_LL brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YU brm_YUU\012";
 name = class51;
 },
 {
 code = "brm_THA brm_THU brm_THUU brm_TTHA brm_TTHU brm_TTHUU";
 name = class53;
+},
+{
+code = "brm_KA brm_NGA brm_CA brm_NYA brm_TTA brm_NNA brm_TA brm_NA brm_PA brm_MA brm_YA brm_RA brm_LA brm_VA brm_LLLA brm_OldTamilLLA brm_RRA brm_NNNA SA brm_SHA brm_DHA brm_shortE\012";
+name = class54;
+},
+{
+code = "brm_OldTamilVirama brm_OldTamilVirama.alt brm_vowelAA brm_vowelI brm_vowelII brm_vowelU brm_vowelUU brm_vowelU.alt brm_vowelUU.alt brm_vowelUU.alt2 brm_vowelShortE brm_vowelEE brm_vowelShortO brm_vowelOO brm_vowelAI brm_vowelAU\012";
+name = class55;
 }
 );
 copyright = "Copyright 2022 The Noto Project Authors (https://github.com/notofonts/brahmi)";
@@ -202,6 +229,12 @@ brm_digit6,
 brm_digit7,
 brm_digit8,
 brm_digit9,
+brm_OldTamilVirama,
+brm_shortE,
+brm_shortO,
+brm_vowelShortE,
+brm_vowelShortO,
+brm_OldTamilLLA,
 brm_GHU,
 brm_GHUU,
 brm_NGU,
@@ -333,6 +366,14 @@ brm_DHUU,
 brm_BHAU,
 brm_TRR,
 brm_TUU,
+brm_DHAshortO,
+brm_LLLAshortO,
+brm_MAshortO,
+brm_NNNAshortO,
+brm_NYAshortO,
+brm_RRAVirama,
+brm_RRAshortO,
+brm_OldTamilVirama.alt,
 brm_vowelU.alt,
 brm_vowelUU.alt,
 brm_vowelUU.alt2,
@@ -415,15 +456,15 @@ code = "lookup LigatureSubstitution1 {\012    lookupflag 0;\012    ;\012    sub 
 name = LigatureSubstitution1;
 },
 {
-code = "lookup LigatureSubstitution2 {\012    lookupflag 0;\012    ;\012    # Original source: 1 \012    sub brm_GHA brm_vowelU by brm_GHU;\012    sub brm_GHA brm_vowelUU by brm_GHUU;\012    sub brm_NGA brm_vowelU by brm_NGU;\012    sub brm_NGA brm_vowelUU by brm_NGUU;\012    sub brm_CA brm_vowelU by brm_CU;\012    sub brm_CA brm_vowelUU by brm_CUU;\012    sub brm_CHA brm_vowelU by brm_CHU;\012    sub brm_CHA brm_vowelUU by brm_CHUU;\012    sub brm_JA brm_vowelAA by brm_JAA;\012    sub brm_JA brm_vowelAU by brm_JAU;\012    sub brm_JA brm_vowelOO by brm_JO;\012    sub brm_JA brm_vowelU by brm_JU;\012    sub brm_JA brm_vowelUU by brm_JUU;\012    sub brm_JHA brm_vowelAU by brm_JHAU;\012    sub brm_JHA brm_vowelOO by brm_JHO;\012    sub brm_NYA brm_vowelAU by brm_NYAU;\012    sub brm_NYA brm_vowelOO by brm_NYO;\012    sub brm_TTA brm_vowelU by brm_TTU;\012    sub brm_TTA brm_vowelUU by brm_TTUU;\012    sub brm_TTHA brm_VOCALIC_R by brm_TTHR;\012    sub brm_TTHA brm_VOCALIC_RR by brm_TTHRR;\012    sub brm_TTHA brm_vowelAI by brm_TTHAI;\012    sub brm_TTHA brm_vowelAU by brm_TTHAU;\012    sub brm_TTHA brm_vowelEE by brm_TTHEE;\012    sub brm_TTHA brm_vowelOO by brm_TTHO;\012    sub brm_TTHA brm_vowelU by brm_TTHU;\012    sub brm_TTHA brm_vowelUU by brm_TTHUU;\012    sub brm_DDHA brm_vowelU by brm_DDHU;\012    sub brm_DDHA brm_vowelUU by brm_DDHUU;\012    sub brm_NNA brm_vowelU by brm_NNU;\012    sub brm_NNA brm_vowelUU by brm_NNUU;\012    sub brm_TA brm_VOCALIC_RR by brm_TRR;\012    sub brm_TA brm_vowelUU by brm_TUU;\012    sub brm_THA brm_VOCALIC_R by brm_THR;\012    sub brm_THA brm_VOCALIC_RR by brm_THRR;\012    sub brm_THA brm_vowelAI by brm_THAI;\012    sub brm_THA brm_vowelAU by brm_THAU;\012    sub brm_THA brm_vowelEE by brm_THEE;\012    sub brm_THA brm_vowelOO by brm_THO;\012    sub brm_THA brm_vowelU by brm_THU;\012    sub brm_THA brm_vowelUU by brm_THUU;\012    sub brm_DA brm_vowelAU by brm_DAU;\012    sub brm_DHA brm_vowelAU by brm_DHAU;\012    sub brm_DHA brm_vowelOO by brm_DHO;\012    sub brm_DHA brm_vowelU by brm_DHU;\012    sub brm_DHA brm_vowelUU by brm_DHUU;\012    sub brm_NA brm_vowelU by brm_NU;\012    sub brm_NA brm_vowelUU by brm_NUU;\012    sub brm_PA brm_vowelU by brm_PU;\012    sub brm_PA brm_vowelUU by brm_PUU;\012    sub brm_PHA brm_vowelU by brm_PHU;\012    sub brm_PHA brm_vowelUU by brm_PHUU;\012    sub brm_BA brm_vowelAU by brm_BAU;\012    sub brm_BA brm_vowelOO by brm_BO;\012    sub brm_BA brm_vowelU by brm_BU;\012    sub brm_BA brm_vowelUU by brm_BUU;\012    sub brm_BHA brm_vowelAU by brm_BHAU;\012    sub brm_MA brm_vowelAU by brm_MAU;\012    sub brm_MA brm_vowelOO by brm_MO;\012    sub brm_MA brm_vowelU by brm_MU;\012    sub brm_MA brm_vowelUU by brm_MUU;\012    sub brm_YA brm_vowelU by brm_YU;\012    sub brm_YA brm_vowelUU by brm_YUU;\012    sub brm_LA brm_vowelU by brm_LU;\012    sub brm_LA brm_vowelUU by brm_LUU;\012    sub brm_VA brm_vowelU by brm_VU;\012    sub brm_VA brm_vowelUU by brm_VUU;\012    sub brm_SSA brm_vowelU by brm_SSU;\012    sub brm_SSA brm_vowelUU by brm_SSUU;\012    sub SA brm_vowelU by brm_SU;\012    sub SA brm_vowelUU by brm_SUU;\012    sub brm_HA brm_vowelU by brm_HU;\012    sub brm_HA brm_vowelUU by brm_HUU;\012    sub brm_LLA brm_vowelU by brm_LLU;\012    sub brm_LLA brm_vowelUU by brm_LLUU;\012    sub brm_LLLA brm_vowelAU by brm_LLLAU;\012    sub brm_LLLA brm_vowelOO by brm_LLLO;\012    sub brm_RRA brm_vowelAU by brm_RRAU;\012    sub brm_RRA brm_vowelOO by brm_RRO;\012    sub brm_NNNA brm_vowelAU by brm_NNNAU;\012    sub brm_NNNA brm_vowelOO by brm_NNNO;\012    sub brm_NNNA brm_vowelU by brm_NNNU;\012    sub brm_NNNA brm_vowelUU by brm_NNNUU;\012} LigatureSubstitution2;\012";
+code = "lookup LigatureSubstitution2 {\012    lookupflag 0;\012    ;\012    # Original source: 1 \012    sub brm_GHA brm_vowelU by brm_GHU;\012    sub brm_GHA brm_vowelUU by brm_GHUU;\012    sub brm_NGA brm_vowelU by brm_NGU;\012    sub brm_NGA brm_vowelUU by brm_NGUU;\012    sub brm_CA brm_vowelU by brm_CU;\012    sub brm_CA brm_vowelUU by brm_CUU;\012    sub brm_CHA brm_vowelU by brm_CHU;\012    sub brm_CHA brm_vowelUU by brm_CHUU;\012    sub brm_JA brm_vowelAA by brm_JAA;\012    sub brm_JA brm_vowelAU by brm_JAU;\012    sub brm_JA brm_vowelOO by brm_JO;\012    sub brm_JA brm_vowelU by brm_JU;\012    sub brm_JA brm_vowelUU by brm_JUU;\012    sub brm_JHA brm_vowelAU by brm_JHAU;\012    sub brm_JHA brm_vowelOO by brm_JHO;\012    sub brm_NYA brm_vowelAU by brm_NYAU;\012    sub brm_NYA brm_vowelOO by brm_NYO;\012    sub brm_TTA brm_vowelU by brm_TTU;\012    sub brm_TTA brm_vowelUU by brm_TTUU;\012    sub brm_TTHA brm_VOCALIC_R by brm_TTHR;\012    sub brm_TTHA brm_VOCALIC_RR by brm_TTHRR;\012    sub brm_TTHA brm_vowelAI by brm_TTHAI;\012    sub brm_TTHA brm_vowelAU by brm_TTHAU;\012    sub brm_TTHA brm_vowelEE by brm_TTHEE;\012    sub brm_TTHA brm_vowelOO by brm_TTHO;\012    sub brm_TTHA brm_vowelU by brm_TTHU;\012    sub brm_TTHA brm_vowelUU by brm_TTHUU;\012    sub brm_DDHA brm_vowelU by brm_DDHU;\012    sub brm_DDHA brm_vowelUU by brm_DDHUU;\012    sub brm_NNA brm_vowelU by brm_NNU;\012    sub brm_NNA brm_vowelUU by brm_NNUU;\012    sub brm_TA brm_VOCALIC_RR by brm_TRR;\012    sub brm_TA brm_vowelUU by brm_TUU;\012    sub brm_THA brm_VOCALIC_R by brm_THR;\012    sub brm_THA brm_VOCALIC_RR by brm_THRR;\012    sub brm_THA brm_vowelAI by brm_THAI;\012    sub brm_THA brm_vowelAU by brm_THAU;\012    sub brm_THA brm_vowelEE by brm_THEE;\012    sub brm_THA brm_vowelOO by brm_THO;\012    sub brm_THA brm_vowelU by brm_THU;\012    sub brm_THA brm_vowelUU by brm_THUU;\012    sub brm_DA brm_vowelAU by brm_DAU;\012    sub brm_DHA brm_vowelAU by brm_DHAU;\012    sub brm_DHA brm_vowelOO by brm_DHO;\012    sub brm_DHA brm_vowelU by brm_DHU;\012    sub brm_DHA brm_vowelUU by brm_DHUU;\012    sub brm_NA brm_vowelU by brm_NU;\012    sub brm_NA brm_vowelUU by brm_NUU;\012    sub brm_PA brm_vowelU by brm_PU;\012    sub brm_PA brm_vowelUU by brm_PUU;\012    sub brm_PHA brm_vowelU by brm_PHU;\012    sub brm_PHA brm_vowelUU by brm_PHUU;\012    sub brm_BA brm_vowelAU by brm_BAU;\012    sub brm_BA brm_vowelOO by brm_BO;\012    sub brm_BA brm_vowelU by brm_BU;\012    sub brm_BA brm_vowelUU by brm_BUU;\012    sub brm_BHA brm_vowelAU by brm_BHAU;\012    sub brm_MA brm_vowelAU by brm_MAU;\012    sub brm_MA brm_vowelOO by brm_MO;\012    sub brm_MA brm_vowelU by brm_MU;\012    sub brm_MA brm_vowelUU by brm_MUU;\012    sub brm_YA brm_vowelU by brm_YU;\012    sub brm_YA brm_vowelUU by brm_YUU;\012    sub brm_LA brm_vowelU by brm_LU;\012    sub brm_LA brm_vowelUU by brm_LUU;\012    sub brm_VA brm_vowelU by brm_VU;\012    sub brm_VA brm_vowelUU by brm_VUU;\012    sub brm_SSA brm_vowelU by brm_SSU;\012    sub brm_SSA brm_vowelUU by brm_SSUU;\012    sub SA brm_vowelU by brm_SU;\012    sub SA brm_vowelUU by brm_SUU;\012    sub brm_HA brm_vowelU by brm_HU;\012    sub brm_HA brm_vowelUU by brm_HUU;\012    sub brm_OldTamilLLA brm_vowelU by brm_LLU;\012    sub brm_OldTamilLLA brm_vowelUU by brm_LLUU;\012    sub brm_LLLA brm_vowelAU by brm_LLLAU;\012    sub brm_LLLA brm_vowelOO by brm_LLLO;\012    sub brm_RRA brm_vowelAU by brm_RRAU;\012    sub brm_RRA brm_vowelOO by brm_RRO;\012    sub brm_NNNA brm_vowelAU by brm_NNNAU;\012    sub brm_NNNA brm_vowelOO by brm_NNNO;\012    sub brm_NNNA brm_vowelU by brm_NNNU;\012    sub brm_NNNA brm_vowelUU by brm_NNNUU;\012	sub brm_RRA brm_OldTamilVirama by brm_RRAVirama;\012	sub brm_NYA brm_vowelShortO by brm_NYAshortO;\012	sub brm_DHA brm_vowelShortO by brm_DHAshortO;\012	sub brm_MA brm_vowelShortO by brm_MAshortO;\012	sub brm_LLLA brm_vowelShortO by brm_LLLAshortO;\012	sub brm_RRA brm_vowelShortO by brm_RRAshortO;\012	sub brm_NNNA brm_vowelShortO by brm_NNNAshortO;\012	\012} LigatureSubstitution2;\012";
 name = LigatureSubstitution2;
 },
 {
-code = "lookup SingleSubstitution5 {\012    lookupflag 0;\012    ;\012    # Original source: 4 \012    sub candrabindu by candrabindu.alt;\012} SingleSubstitution5;\012";
+code = "lookup SingleSubstitution5 {\012    lookupflag 0;\012    ;\012    # Original source: 4 \012    sub candrabindu by candrabindu.alt;\012	sub brm_OldTamilVirama by brm_OldTamilVirama.alt;\012} SingleSubstitution5;\012";
 name = SingleSubstitution5;
 },
 {
-code = "lookup ChainedContextualGSUB3 {\012    lookupflag 0;\012    ;\012    # Original source: 2 \012    sub @class1 candrabindu' lookup SingleSubstitution5;\012} ChainedContextualGSUB3;\012";
+code = "lookup ChainedContextualGSUB3 {\012    lookupflag 0;\012    ;\012    # Original source: 2 \012    sub @class1 candrabindu' lookup SingleSubstitution5;\012	sub [brm_KA brm_PA brm_YA brm_OldTamilLLA SA brm_NYA brm_NGA brm_TTA brm_NNA] brm_OldTamilVirama' lookup SingleSubstitution5;\012} ChainedContextualGSUB3;\012";
 name = ChainedContextualGSUB3;
 },
 {
@@ -443,67 +484,75 @@ code = "lookup SingleSubstitution7 {\012    lookupflag 0;\012    ;\012    # Orig
 name = SingleSubstitution7;
 },
 {
-code = "lookup ContextualGSUB6 {\012    lookupflag 0;\012    ;\012    # Original source: 5 \012    sub [brm_NYA brm_LLLA brm_JNYA]' brm_vowelUU' lookup SingleSubstitution7;\012    sub @class2' brm_VOCALIC_RR' lookup SingleSubstitution8;\012    sub @class2' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub brm_SHA' brm_vowelUU' lookup SingleSubstitution8;\012    sub brm_SHA' brm_VOCALIC_RR' lookup SingleSubstitution9;\012    sub brm_SHA' brm_VOCALIC_R' lookup SingleSubstitution9;\012    sub brm_SHA' brm_vowelU' lookup SingleSubstitution7;\012    sub [brm_LA brm_LLA]' brm_VOCALIC_RR' lookup SingleSubstitution7;\012    sub [brm_LA brm_LLA]' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub brm_DA' brm_vowelUU' lookup SingleSubstitution7;\012    sub brm_DA' brm_VOCALIC_RR' lookup SingleSubstitution7;\012    sub brm_DA' brm_VOCALIC_R' lookup SingleSubstitution7;\012    sub SA' brm_VOCALIC_RR' lookup SingleSubstitution9;\012    sub SA' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub [brm_SVA brm_KSSA]' brm_VOCALIC_RR' lookup SingleSubstitution8;\012    sub [brm_SVA brm_KSSA]' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub [brm_SVA brm_KSSA]' brm_vowelUU' lookup SingleSubstitution9;\012    sub [brm_SVA brm_KSSA]' brm_vowelU' lookup SingleSubstitution9;\012} ContextualGSUB6;\012";
+code = "lookup ContextualGSUB6 {\012    lookupflag 0;\012    ;\012    # Original source: 5 \012    sub [brm_NYA brm_LLLA brm_JNYA]' brm_vowelUU' lookup SingleSubstitution7;\012    sub @class2' brm_VOCALIC_RR' lookup SingleSubstitution8;\012    sub @class2' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub brm_SHA' brm_vowelUU' lookup SingleSubstitution8;\012    sub brm_SHA' brm_VOCALIC_RR' lookup SingleSubstitution9;\012    sub brm_SHA' brm_VOCALIC_R' lookup SingleSubstitution9;\012    sub brm_SHA' brm_vowelU' lookup SingleSubstitution7;\012    sub [brm_LA brm_OldTamilLLA]' brm_VOCALIC_RR' lookup SingleSubstitution7;\012    sub [brm_LA brm_OldTamilLLA]' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub brm_DA' brm_vowelUU' lookup SingleSubstitution7;\012    sub brm_DA' brm_VOCALIC_RR' lookup SingleSubstitution7;\012    sub brm_DA' brm_VOCALIC_R' lookup SingleSubstitution7;\012    sub SA' brm_VOCALIC_RR' lookup SingleSubstitution9;\012    sub SA' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub [brm_SVA brm_KSSA]' brm_VOCALIC_RR' lookup SingleSubstitution8;\012    sub [brm_SVA brm_KSSA]' brm_VOCALIC_R' lookup SingleSubstitution8;\012    sub [brm_SVA brm_KSSA]' brm_vowelUU' lookup SingleSubstitution9;\012    sub [brm_SVA brm_KSSA]' brm_vowelU' lookup SingleSubstitution9;\012} ContextualGSUB6;\012";
 name = ContextualGSUB6;
 },
 {
-code = "lookup SinglePositioning34 {\012    lookupflag 0;\012    ;\012    # Original source: 20 \012    pos brm_A <122 0 122 0>;\012    pos brm_AA <122 0 122 0>;\012    pos brm_I <122 0 122 0>;\012    pos brm_II <122 0 122 0>;\012    pos brm_U <122 0 122 0>;\012    pos brm_UU <122 0 122 0>;\012    pos brm_R <122 0 122 0>;\012    pos brm_RR <122 0 122 0>;\012    pos brm_L <122 0 122 0>;\012    pos brm_LL <122 0 122 0>;\012    pos brm_E <122 0 122 0>;\012    pos brm_AI <122 0 122 0>;\012    pos brm_O <122 0 122 0>;\012    pos brm_AU <122 0 122 0>;\012    pos brm_KHA <122 0 122 0>;\012    pos brm_GA <140 0 140 0>;\012    pos brm_GHA <122 0 122 0>;\012    pos brm_NGA <122 0 122 0>;\012    pos brm_JA <122 0 122 0>;\012    pos brm_JHA <122 0 122 0>;\012    pos brm_NYA <122 0 122 0>;\012    pos brm_TTA <122 0 122 0>;\012    pos brm_TTHA <49 0 49 0>;\012    pos brm_DDA <122 0 122 0>;\012    pos brm_DDHA <122 0 122 0>;\012    pos brm_NNA <122 0 122 0>;\012    pos brm_TA <140 0 140 0>;\012    pos brm_THA <49 0 49 0>;\012    pos brm_DA <122 0 122 0>;\012    pos brm_DHA <122 0 122 0>;\012    pos brm_PA <122 0 122 0>;\012    pos brm_PHA <122 0 122 0>;\012    pos brm_BA <122 0 122 0>;\012    pos brm_BHA <122 0 122 0>;\012    pos brm_MA <122 0 122 0>;\012    pos brm_RA <122 0 122 0>;\012    pos brm_VA <122 0 122 0>;\012    pos brm_SHA <140 0 140 0>;\012    pos brm_SSA <122 0 122 0>;\012    pos brm_HA <122 0 122 0>;\012    pos brm_RRA <122 0 122 0>;\012    pos brm_NNNA <122 0 122 0>;\012    pos brm_GHU <122 0 122 0>;\012    pos brm_GHUU <122 0 122 0>;\012    pos brm_NGU <122 0 122 0>;\012    pos brm_NGUU <122 0 122 0>;\012    pos brm_CU <122 0 122 0>;\012    pos brm_CUU <122 0 122 0>;\012    pos brm_CHU <122 0 122 0>;\012    pos brm_CHUU <122 0 122 0>;\012    pos brm_JAA <122 0 122 0>;\012    pos brm_JO <122 0 122 0>;\012    pos brm_JAU <122 0 122 0>;\012    pos brm_JU <122 0 122 0>;\012    pos brm_JUU <122 0 122 0>;\012    pos brm_JHO <122 0 122 0>;\012    pos brm_JHAU <122 0 122 0>;\012    pos brm_NYO <122 0 122 0>;\012    pos brm_NYAU <122 0 122 0>;\012    pos brm_TTU <122 0 122 0>;\012    pos brm_TTUU <122 0 122 0>;\012    pos brm_TTHO <122 0 122 0>;\012    pos brm_TTHAU <122 0 122 0>;\012    pos brm_TTHU <49 0 49 0>;\012    pos brm_TTHUU <49 0 49 0>;\012    pos brm_DDHU <122 0 122 0>;\012    pos brm_DDHUU <122 0 122 0>;\012    pos brm_NNU <122 0 122 0>;\012    pos brm_NNUU <122 0 122 0>;\012    pos brm_THO <122 0 122 0>;\012    pos brm_THAU <122 0 122 0>;\012    pos brm_THU <49 0 49 0>;\012    pos brm_THUU <49 0 49 0>;\012    pos brm_DHO <122 0 122 0>;\012    pos brm_DHAU <122 0 122 0>;\012    pos brm_NU <122 0 122 0>;\012    pos brm_NUU <122 0 122 0>;\012    pos brm_PU <122 0 122 0>;\012    pos brm_PUU <122 0 122 0>;\012    pos brm_PHU <122 0 122 0>;\012    pos brm_PHUU <122 0 122 0>;\012    pos brm_BO <122 0 122 0>;\012    pos brm_BAU <122 0 122 0>;\012    pos brm_BU <122 0 122 0>;\012    pos brm_BUU <122 0 122 0>;\012    pos brm_MO <122 0 122 0>;\012    pos brm_MAU <122 0 122 0>;\012    pos brm_MU <122 0 122 0>;\012    pos brm_MUU <122 0 122 0>;\012    pos brm_YU <122 0 122 0>;\012    pos brm_YUU <122 0 122 0>;\012    pos brm_LU <122 0 122 0>;\012    pos brm_LUU <122 0 122 0>;\012    pos brm_VU <122 0 122 0>;\012    pos brm_VUU <122 0 122 0>;\012    pos brm_SSU <122 0 122 0>;\012    pos brm_SSUU <122 0 122 0>;\012    pos brm_SU <122 0 122 0>;\012    pos brm_SUU <122 0 122 0>;\012    pos brm_HU <122 0 122 0>;\012    pos brm_HUU <122 0 122 0>;\012    pos brm_LLU <122 0 122 0>;\012    pos brm_LLUU <122 0 122 0>;\012    pos brm_LLLO <122 0 122 0>;\012    pos brm_LLLAU <122 0 122 0>;\012    pos brm_RRO <122 0 122 0>;\012    pos brm_RRAU <122 0 122 0>;\012    pos brm_NNNO <122 0 122 0>;\012    pos brm_NNNAU <122 0 122 0>;\012    pos brm_NNNU <122 0 122 0>;\012    pos brm_NNNUU <122 0 122 0>;\012    pos brm_SVA <122 0 122 0>;\012    pos brm_KSSA <122 0 122 0>;\012    pos brm_JNYA <122 0 122 0>;\012    pos brm_TTHEE <122 0 122 0>;\012    pos brm_TTHAI <122 0 122 0>;\012    pos brm_THEE <122 0 122 0>;\012    pos brm_THAI <122 0 122 0>;\012    pos brm_TTHR <122 0 122 0>;\012    pos brm_THR <122 0 122 0>;\012    pos brm_TTHRR <122 0 122 0>;\012    pos brm_THRR <122 0 122 0>;\012    pos brm_DAU <122 0 122 0>;\012    pos brm_DHU <122 0 122 0>;\012    pos brm_DHUU <122 0 122 0>;\012    pos brm_BHAU <122 0 122 0>;\012    pos brm_TRR <140 0 140 0>;\012    pos brm_TUU <140 0 0 0>;\012} SinglePositioning34;\012";
+code = "lookup SinglePositioning34 {\012    lookupflag 0;\012    ;\012    # Original source: 20 \012    pos brm_A <122 0 122 0>;\012    pos brm_AA <122 0 122 0>;\012    pos brm_I <122 0 122 0>;\012    pos brm_II <122 0 122 0>;\012    pos brm_U <122 0 122 0>;\012    pos brm_UU <122 0 122 0>;\012    pos brm_R <122 0 122 0>;\012    pos brm_RR <122 0 122 0>;\012    pos brm_L <122 0 122 0>;\012    pos brm_LL <122 0 122 0>;\012    pos brm_E <122 0 122 0>;\012    pos brm_AI <122 0 122 0>;\012    pos brm_O <122 0 122 0>;\012	pos brm_shortO <122 0 122 0>;\012    pos brm_AU <122 0 122 0>;\012    pos brm_KHA <122 0 122 0>;\012    pos brm_GA <140 0 140 0>;\012    pos brm_GHA <122 0 122 0>;\012    pos brm_NGA <122 0 122 0>;\012    pos brm_JA <122 0 122 0>;\012    pos brm_JHA <122 0 122 0>;\012    pos brm_NYA <122 0 122 0>;\012    pos brm_TTA <122 0 122 0>;\012    pos brm_TTHA <49 0 49 0>;\012    pos brm_DDA <122 0 122 0>;\012	pos brm_LLA <122 0 122 0>;\012    pos brm_DDHA <122 0 122 0>;\012    pos brm_NNA <172 0 172 0>;\012    pos brm_TA <140 0 140 0>;\012    pos brm_THA <49 0 49 0>;\012    pos brm_DA <122 0 122 0>;\012    pos brm_DHA <122 0 122 0>;\012	pos brm_shortE <122 0 122 0>;\012    pos brm_PA <122 0 122 0>;\012    pos brm_PHA <122 0 122 0>;\012    pos brm_BA <122 0 122 0>;\012    pos brm_BHA <122 0 122 0>;\012    pos brm_MA <172 0 172 0>;\012    pos brm_RA <122 0 122 0>;\012    pos brm_VA <122 0 122 0>;\012    pos brm_SHA <140 0 140 0>;\012    pos brm_SSA <122 0 122 0>;\012    pos brm_HA <122 0 122 0>;\012    pos brm_RRA <122 0 122 0>;\012	pos brm_RRAVirama <122 0 122 0>;\012    pos brm_NNNA <122 0 122 0>;\012    pos brm_GHU <122 0 122 0>;\012    pos brm_GHUU <122 0 122 0>;\012    pos brm_NGU <122 0 122 0>;\012    pos brm_NGUU <122 0 122 0>;\012    pos brm_CU <122 0 122 0>;\012    pos brm_CUU <122 0 122 0>;\012    pos brm_CHU <122 0 122 0>;\012    pos brm_CHUU <122 0 122 0>;\012    pos brm_JAA <122 0 122 0>;\012    pos brm_JO <122 0 122 0>;\012    pos brm_JAU <122 0 122 0>;\012    pos brm_JU <122 0 122 0>;\012    pos brm_JUU <122 0 122 0>;\012    pos brm_JHO <122 0 122 0>;\012    pos brm_JHAU <122 0 122 0>;\012    pos brm_NYO <122 0 122 0>;\012	pos brm_NYAshortO <122 0 122 0>;\012    pos brm_NYAU <122 0 122 0>;\012    pos brm_TTU <122 0 122 0>;\012    pos brm_TTUU <122 0 122 0>;\012    pos brm_TTHO <122 0 122 0>;\012    pos brm_TTHAU <122 0 122 0>;\012    pos brm_TTHU <49 0 49 0>;\012    pos brm_TTHUU <49 0 49 0>;\012    pos brm_DDHU <122 0 122 0>;\012    pos brm_DDHUU <122 0 122 0>;\012    pos brm_NNU <122 0 122 0>;\012    pos brm_NNUU <122 0 122 0>;\012    pos brm_THO <122 0 122 0>;\012    pos brm_THAU <122 0 122 0>;\012    pos brm_THU <49 0 49 0>;\012    pos brm_THUU <49 0 49 0>;\012    pos brm_DHO <122 0 122 0>;\012	pos brm_DHAshortO <122 0 122 0>;\012    pos brm_DHAU <122 0 122 0>;\012    pos brm_NU <122 0 122 0>;\012    pos brm_NUU <122 0 122 0>;\012    pos brm_PU <122 0 122 0>;\012    pos brm_PUU <122 0 122 0>;\012    pos brm_PHU <122 0 122 0>;\012    pos brm_PHUU <122 0 122 0>;\012    pos brm_BO <122 0 122 0>;\012    pos brm_BAU <122 0 122 0>;\012    pos brm_BU <122 0 122 0>;\012    pos brm_BUU <122 0 122 0>;\012    pos brm_MO <122 0 122 0>;\012	pos brm_MAshortO <122 0 122 0>;\012    pos brm_MAU <122 0 122 0>;\012    pos brm_MU <122 0 122 0>;\012    pos brm_MUU <122 0 122 0>;\012    pos brm_YU <122 0 122 0>;\012    pos brm_YUU <122 0 122 0>;\012    pos brm_LU <122 0 122 0>;\012    pos brm_LUU <122 0 122 0>;\012    pos brm_VU <122 0 122 0>;\012    pos brm_VUU <122 0 122 0>;\012    pos brm_SSU <122 0 122 0>;\012    pos brm_SSUU <122 0 122 0>;\012    pos brm_SU <122 0 122 0>;\012    pos brm_SUU <122 0 122 0>;\012    pos brm_HU <122 0 122 0>;\012    pos brm_HUU <122 0 122 0>;\012    pos brm_LLU <122 0 122 0>;\012    pos brm_LLUU <122 0 122 0>;\012    pos brm_LLLO <122 0 122 0>;\012	pos brm_LLLAshortO <122 0 122 0>;\012    pos brm_LLLAU <122 0 122 0>;\012    pos brm_RRO <122 0 122 0>;\012	pos brm_RRAshortO <122 0 122 0>;\012    pos brm_RRAU <122 0 122 0>;\012    pos brm_NNNO <122 0 122 0>;\012	pos brm_NNNAshortO <122 0 122 0>;\012    pos brm_NNNAU <122 0 122 0>;\012    pos brm_NNNU <122 0 122 0>;\012    pos brm_NNNUU <122 0 122 0>;\012    pos brm_SVA <122 0 122 0>;\012    pos brm_KSSA <122 0 122 0>;\012    pos brm_JNYA <122 0 122 0>;\012    pos brm_TTHEE <122 0 122 0>;\012    pos brm_TTHAI <122 0 122 0>;\012    pos brm_THEE <122 0 122 0>;\012    pos brm_THAI <122 0 122 0>;\012    pos brm_TTHR <122 0 122 0>;\012    pos brm_THR <122 0 122 0>;\012    pos brm_TTHRR <122 0 122 0>;\012    pos brm_THRR <122 0 122 0>;\012    pos brm_DAU <122 0 122 0>;\012    pos brm_DHU <122 0 122 0>;\012    pos brm_DHUU <122 0 122 0>;\012    pos brm_BHAU <122 0 122 0>;\012    pos brm_TRR <140 0 140 0>;\012    pos brm_TUU <140 0 0 0>;\012	pos brm_OldTamilLLA <193 0 193 0>;\012	pos brm_CA <122 0 122 0>;\012	pos brm_NA <172 0 172 0>;\012	pos brm_YA <172 0 172 0>;\012	pos brm_LA <172 0 172 0>;\012	pos brm_LLLA <172 0 172 0>;\012	pos SA <172 0 172 0>;\012	pos brm_KA <172 0 172 0>;\012} SinglePositioning34;\012";
 name = SinglePositioning34;
 },
 {
-code = "lookup ChainedContextualGPOS1 {\012    lookupflag 0;\012    ;\012    pos @class5 brm_vowelII @class4' lookup SinglePositioning34;\012    pos @class5 brm_vowelI @class6' lookup SinglePositioning34;\012    pos @class9 brm_vowelAA @class4' lookup SinglePositioning34;\012    pos [brm_KHA brm_GA brm_TA brm_RA brm_RRA] brm_vowelU @class10' lookup SinglePositioning34;\012    pos [brm_KHA brm_GA brm_TA brm_RA brm_RRA] brm_vowelUU @class10' lookup SinglePositioning34;\012} ChainedContextualGPOS1;\012";
+code = "lookup ChainedContextualGPOS1 {\012    lookupflag 0;\012    ;\012    pos @class5 brm_vowelII @class4' lookup SinglePositioning34;\012    pos @class5 brm_vowelI @class6' lookup SinglePositioning34;\012    pos @class9 brm_vowelAA @class4' lookup SinglePositioning34;\012	#glyphs that combine with vowelU and vowelUU such that it sticks out in the bottom right\012    pos [brm_KHA brm_GA brm_TA brm_RA brm_RRA] brm_vowelU @class10' lookup SinglePositioning34;\012    pos [brm_KHA brm_GA brm_TA brm_RA brm_RRA] brm_vowelUU @class10' lookup SinglePositioning34;\012} ChainedContextualGPOS1;\012";
 name = ChainedContextualGPOS1;
 },
 {
-code = "lookup SinglePositioning35 {\012    lookupflag 0;\012    ;\012    # Original source: 21 \012    pos [brm_AU brm_NYA brm_O] <49 0 49 0>;\012} SinglePositioning35;\012";
+code = "lookup SinglePositioning35 {\012    lookupflag 0;\012    ;\012    # Original source: 21 \012    pos [brm_AU brm_NYA brm_O brm_shortO] <49 0 49 0>;\012} SinglePositioning35;\012";
 name = SinglePositioning35;
 },
 {
-code = "lookup ChainedContextualGPOS2 {\012    lookupflag 0;\012    ;\012    # Original source: 1 \012    pos @class9 brm_vowelII [brm_O brm_AU brm_NYA]' lookup SinglePositioning35;\012    pos @class9 brm_vowelAA [brm_O brm_AU brm_NYA]' lookup SinglePositioning35;\012    pos @class9 brm_vowelI [brm_O brm_AU brm_NYA]' lookup SinglePositioning35;\012} ChainedContextualGPOS2;\012";
+code = "lookup ChainedContextualGPOS2 {\012    lookupflag 0;\012    ;\012    # Original source: 1 \012    pos @class9 brm_vowelII [brm_O brm_shortO brm_AU brm_NYA]' lookup SinglePositioning35;\012    pos @class9 brm_vowelAA [brm_O brm_shortO brm_AU brm_NYA]' lookup SinglePositioning35;\012    pos @class9 brm_vowelI [brm_O brm_shortO brm_AU brm_NYA]' lookup SinglePositioning35;\012} ChainedContextualGPOS2;\012";
 name = ChainedContextualGPOS2;
 },
 {
-code = "lookup SinglePositioning36 {\012    lookupflag 0;\012    ;\012    # Original source: 22 \012    pos [SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_LLA brm_LLLA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU] <146 0 146 0>;\012} SinglePositioning36;\012";
+code = "lookup SinglePositioning36 {\012    lookupflag 0;\012    ;\012    # Original source: 22 \012    pos [SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_OldTamilLLA brm_LLLA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU] <146 0 146 0>;\012} SinglePositioning36;\012";
 name = SinglePositioning36;
 },
 {
-code = "lookup ChainedContextualGPOS3 {\012    lookupflag 0;\012    ;\012    # Original source: 2 \012    pos brm_KHA [brm_vowelOO brm_vowelAU] @class15' lookup SinglePositioning36;\012    pos brm_CA [brm_vowelOO brm_vowelAU] @class15' lookup SinglePositioning36;\012    pos brm_DDA [brm_vowelOO brm_vowelAU] @class15' lookup SinglePositioning36;\012    pos brm_RA [brm_vowelOO brm_vowelAU] @class18' lookup SinglePositioning36;\012    pos brm_LA [brm_vowelOO brm_vowelAU] @class18' lookup SinglePositioning36;\012} ChainedContextualGPOS3;\012";
+code = "lookup ChainedContextualGPOS3 {\012    lookupflag 0;\012    ;\012    # Original source: 2 \012    pos brm_KHA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class15' lookup SinglePositioning36;\012    pos brm_CA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class15' lookup SinglePositioning36;\012    pos brm_DDA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class15' lookup SinglePositioning36;\012    pos brm_RA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class18' lookup SinglePositioning36;\012    pos brm_LA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class18' lookup SinglePositioning36;\012} ChainedContextualGPOS3;\012\012";
 name = ChainedContextualGPOS3;
 },
 {
-code = "lookup SinglePositioning37 {\012    lookupflag 0;\012    ;\012    # Original source: 23 \012    pos [SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_LLA brm_LLLA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU] <49 0 49 0>;\012} SinglePositioning37;\012";
+code = "lookup SinglePositioning37 {\012    lookupflag 0;\012    ;\012    # Original source: 23 \012    pos [SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_OldTamilLLA brm_LLLA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU] <49 0 49 0>;\012} SinglePositioning37;\012";
 name = SinglePositioning37;
 },
 {
-code = "lookup ChainedContextualGPOS4 {\012    lookupflag 0;\012    ;\012    # Original source: 3 \012    pos brm_NNA [brm_vowelOO brm_vowelAU] @class18' lookup SinglePositioning37;\012    pos brm_TA [brm_vowelOO brm_vowelAU] @class21' lookup SinglePositioning37;\012    pos brm_NA [brm_vowelOO brm_vowelAU] @class21' lookup SinglePositioning37;\012    pos brm_VA [brm_vowelOO brm_vowelAU] @class21' lookup SinglePositioning37;\012} ChainedContextualGPOS4;\012";
+code = "lookup ChainedContextualGPOS4 {\012    lookupflag 0;\012    ;\012    # Original source: 3 \012    pos brm_NNA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class18' lookup SinglePositioning37;\012    pos brm_TA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class21' lookup SinglePositioning37;\012    pos brm_NA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class21' lookup SinglePositioning37;\012    pos brm_VA [brm_vowelOO brm_vowelShortO brm_vowelAU] @class21' lookup SinglePositioning37;\012\012} ChainedContextualGPOS4;\012";
 name = ChainedContextualGPOS4;
 },
 {
-code = "lookup SinglePositioning38 {\012    lookupflag 0;\012    ;\012    # Original source: 24 \012    pos [SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_DHAU brm_DHO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_LLA brm_LLLA brm_LLLAU brm_LLLO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_O brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAU brm_RRO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU] <73 0 73 0>;\012} SinglePositioning38;\012";
+code = "lookup SinglePositioning38 {\012    lookupflag 0;\012    ;\012    # Original source: 24 \012    pos [SA brm_A brm_AA brm_AI brm_AU brm_BA brm_BAU brm_BHA brm_BHAU brm_BO brm_BU brm_BUU brm_CA brm_CHA brm_CHU brm_CHUU brm_CU brm_CUU brm_DA brm_DAU brm_DDA brm_LLA brm_DDHA brm_DDHU brm_DDHUU brm_DHA brm_shortE brm_DHAU brm_DHO brm_DHAshortO brm_DHU brm_DHUU brm_E brm_GA brm_GHA brm_GHU brm_GHUU brm_HA brm_HU brm_HUU brm_I brm_II brm_JA brm_JAA brm_JAU brm_JHA brm_JHAU brm_JHO brm_JNYA brm_JO brm_JU brm_JUU brm_KA brm_KHA brm_KSSA brm_L brm_LA brm_LL brm_OldTamilLLA brm_LLLA brm_LLLAU brm_LLLO brm_LLLAshortO brm_LLU brm_LLUU brm_LU brm_LUU brm_MA brm_MAU brm_MO brm_MAshortO brm_MU brm_MUU brm_NA brm_NGA brm_NGU brm_NGUU brm_NNA brm_NNNA brm_NNNAU brm_NNNO brm_NNNAshortO brm_NNNU brm_NNNUU brm_NNU brm_NNUU brm_NU brm_NUU brm_NYA brm_NYAU brm_NYO brm_NYAshortO brm_O brm_shortO brm_PA brm_PHA brm_PHU brm_PHUU brm_PU brm_PUU brm_R brm_RA brm_RR brm_RRA brm_RRAVirama brm_RRAU brm_RRO brm_RRAshortO brm_SHA brm_SSA brm_SSU brm_SSUU brm_SU brm_SUU brm_SVA brm_TA brm_THA brm_THAI brm_THAU brm_THEE brm_THO brm_THR brm_THRR brm_THU brm_THUU brm_TRR brm_TTA brm_TTHA brm_TTHAI brm_TTHAU brm_TTHEE brm_TTHO brm_TTHR brm_TTHRR brm_TTHU brm_TTHUU brm_TTU brm_TTUU brm_TUU brm_U brm_UU brm_VA brm_VU brm_VUU brm_YA brm_YU brm_YUU] <73 0 73 0>;\012} SinglePositioning38;\012";
 name = SinglePositioning38;
 },
 {
-code = "lookup ChainedContextualGPOS5 {\012    lookupflag 0;\012    ;\012    # Original source: 4 \012    pos @class25 brm_vowelII @class21' lookup SinglePositioning38;\012    pos @class25 brm_vowelI @class21' lookup SinglePositioning38;\012    pos @class25 brm_vowelAA @class21' lookup SinglePositioning38;\012    pos @class25 brm_vowelU @class21' lookup SinglePositioning38;\012    pos @class25 brm_vowelUU @class21' lookup SinglePositioning38;\012} ChainedContextualGPOS5;\012";
+code = "lookup ChainedContextualGPOS5 {\012    lookupflag 0;\012    ;\012    # Original source: 4 \012    pos @class25 brm_vowelII @class21' lookup SinglePositioning38;\012    pos @class25 brm_vowelI @class21' lookup SinglePositioning38;\012    pos @class26 brm_vowelAA @class21' lookup SinglePositioning38;\012    pos @class26 brm_vowelU @class21' lookup SinglePositioning38;\012    pos @class26 brm_vowelUU @class21' lookup SinglePositioning38;\012} ChainedContextualGPOS5;\012";
 name = ChainedContextualGPOS5;
 },
 {
-code = "lookup SinglePositioning39 {\012    lookupflag 0;\012    ;\012    # Original source: 25 \012    pos [brm_AU brm_NNA brm_NYA brm_O] <29 0 29 0>;\012} SinglePositioning39;\012";
+code = "lookup SinglePositioning39 {\012    lookupflag 0;\012    ;\012    # Original source: 25 \012    pos [brm_AU brm_NNA brm_NYA brm_O brm_shortO] <29 0 29 0>;\012} SinglePositioning39;\012";
 name = SinglePositioning39;
 },
 {
-code = "lookup ChainedContextualGPOS6 {\012    lookupflag 0;\012    ;\012    # Original source: 5 \012    pos brm_JA brm_vowelI [brm_O brm_AU brm_NYA brm_NNA]' lookup SinglePositioning39;\012    pos brm_JA brm_vowelII [brm_O brm_AU brm_NYA brm_NNA]' lookup SinglePositioning39;\012} ChainedContextualGPOS6;\012";
+code = "lookup ChainedContextualGPOS6 {\012    lookupflag 0;\012    ;\012    # Original source: 5 \012    pos brm_JA brm_vowelI [brm_O brm_shortO brm_AU brm_NYA brm_NNA]' lookup SinglePositioning39;\012    pos brm_JA brm_vowelII [brm_O brm_shortO brm_AU brm_NYA brm_NNA]' lookup SinglePositioning39;\012} ChainedContextualGPOS6;\012";
 name = ChainedContextualGPOS6;
 },
 {
-code = "lookup SinglePositioning40 {\012    lookupflag 0;\012    ;\012    # Original source: 26 \012    pos brm_AI <73 0 73 0>;\012    pos brm_O <73 0 73 0>;\012    pos brm_AU <73 0 73 0>;\012    pos brm_GA <59 0 59 0>;\012    pos brm_GHA <146 0 146 0>;\012    pos brm_NGA <156 0 156 0>;\012    pos brm_CHA <49 0 49 0>;\012    pos brm_JA <137 0 137 0>;\012    pos brm_JHA <156 0 156 0>;\012    pos brm_NYA <73 0 73 0>;\012    pos brm_TTA <146 0 146 0>;\012    pos brm_DDHA <43 0 43 0>;\012    pos brm_NNA <59 0 59 0>;\012    pos brm_DA <146 0 146 0>;\012    pos brm_DHA <146 0 146 0>;\012    pos brm_NA <49 0 49 0>;\012    pos brm_PA <171 0 171 0>;\012    pos brm_PHA <156 0 156 0>;\012    pos brm_BA <127 0 127 0>;\012    pos brm_MA <146 0 146 0>;\012    pos brm_RA <146 0 146 0>;\012    pos brm_VA <88 0 88 0>;\012    pos brm_SHA <20 0 20 0>;\012    pos brm_SSA <156 0 156 0>;\012    pos brm_HA <156 0 156 0>;\012    pos brm_LLLA <107 0 107 0>;\012    pos brm_RRA <59 0 59 0>;\012    pos brm_NNNA <54 0 54 0>;\012    pos brm_JNYA <120 0 120 0>;\012} SinglePositioning40;\012";
+code = "lookup SinglePositioning40 {\012    lookupflag 0;\012    ;\012    # Original source: 26 \012    pos brm_AI <73 0 73 0>;\012    pos brm_O <73 0 73 0>;\012	pos brm_shortO <73 0 73 0>;\012    pos brm_AU <73 0 73 0>;\012    pos brm_GA <59 0 59 0>;\012    pos brm_GHA <146 0 146 0>;\012	pos brm_KA <76 0 76 0>;\012    pos brm_NGA <156 0 156 0>;\012    pos brm_CHA <49 0 49 0>;\012    pos brm_JA <137 0 137 0>;\012    pos brm_JHA <156 0 156 0>;\012    pos brm_NYA <73 0 73 0>;\012    pos brm_TTA <196 0 196 0>;\012    pos brm_DDHA <43 0 43 0>;\012    pos brm_NNA <59 0 59 0>;\012	pos brm_TA <50 0 50 0>;\012    pos brm_DA <146 0 146 0>;\012    pos brm_DHA <146 0 146 0>;\012	pos brm_shortE <146 0 146 0>;\012    pos brm_NA <99 0 99 0>;\012    pos brm_PA <221 0 221 0>;\012    pos brm_PHA <156 0 156 0>;\012    pos brm_BA <127 0 127 0>;\012    pos brm_MA <196 0 196 0>;\012    pos brm_RA <196 0 196 0>;\012    pos brm_VA <138 0 138 0>;\012    pos brm_SHA <20 0 20 0>;\012    pos brm_SSA <156 0 156 0>;\012    pos brm_HA <156 0 156 0>;\012    pos brm_LLLA <107 0 107 0>;\012    pos brm_RRA <109 0 109 0>;\012	pos brm_RRAVirama <59 0 59 0>;\012    pos brm_NNNA <104 0 104 0>;\012    pos brm_JNYA <120 0 120 0>;\012} SinglePositioning40;\012";
 name = SinglePositioning40;
 },
 {
-code = "lookup ChainedContextualGPOS7 {\012    lookupflag 0;\012    ;\012    # Original source: 6 \012    pos @class35 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012    pos @class37 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012    pos @class39 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012    pos @class41 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012} ChainedContextualGPOS7;\012";
+code = "lookup ChainedContextualGPOS7 {\012    lookupflag 0;\012    ;\012    # Original source: 6 \012	pos @class35 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012    pos @class37 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012    pos @class39 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012    pos @class41 @class34' lookup SinglePositioning40 [brm_vowelEE brm_vowelAI brm_vowelOO brm_vowelAU];\012	\012} ChainedContextualGPOS7;\012";
 name = ChainedContextualGPOS7;
 },
 {
-code = "lookup SinglePositioning44 {\012    lookupflag 0;\012    ;\012    # Original source: 30 \012    pos brm_GA <146 0 146 0>;\012    pos brm_GHA <146 0 146 0>;\012    pos brm_NGA <156 0 156 0>;\012    pos brm_CA <146 0 146 0>;\012    pos brm_CHA <146 0 146 0>;\012    pos brm_JA <137 0 137 0>;\012    pos brm_JHA <137 0 137 0>;\012    pos brm_NYA <43 0 43 0>;\012    pos brm_TTA <110 0 110 0>;\012    pos brm_DDA <110 0 110 0>;\012    pos brm_DDHA <137 0 137 0>;\012    pos brm_NNA <30 0 30 0>;\012    pos brm_DA <137 0 137 0>;\012    pos brm_DHA <146 0 146 0>;\012    pos brm_NA <30 0 30 0>;\012    pos brm_PA <171 0 171 0>;\012    pos brm_PHA <156 0 156 0>;\012    pos brm_BA <127 0 127 0>;\012    pos brm_BHA <127 0 127 0>;\012    pos brm_MA <98 0 98 0>;\012    pos brm_YA <146 0 146 0>;\012    pos brm_RA <146 0 146 0>;\012    pos brm_VA <110 0 110 0>;\012    pos brm_SHA <59 0 59 0>;\012    pos brm_SSA <156 0 156 0>;\012    pos brm_HA <156 0 156 0>;\012    pos brm_LLLA <107 0 107 0>;\012    pos brm_RRA <146 0 146 0>;\012    pos brm_NNNA <54 0 54 0>;\012    pos brm_VOCALIC_R <73 0 73 0>;\012    pos brm_VOCALIC_RR <73 0 73 0>;\012    pos brm_VOCALIC_R.alt2 <73 0 73 0>;\012    pos brm_VOCALIC_RR.alt2 <73 0 73 0>;\012} SinglePositioning44;\012";
+code = "lookup SinglePositioning45 {\012    lookupflag 0;\012    ;\012    # Original source: 26 \012    pos brm_AI <173 0 173 0>;\012    pos brm_O <173 0 173 0>;\012	pos brm_shortO <173 0 173 0>;\012    pos brm_AU <173 0 173 0>;\012    pos brm_GA <159 0 159 0>;\012    pos brm_GHA <246 0 246 0>;\012	pos brm_KA <76 0 76 0>;\012    pos brm_NGA <256 0 256 0>;\012	pos brm_CA <61 0 61 0>;\012    pos brm_CHA <149 0 149 0>;\012    pos brm_JA <237 0 237 0>;\012    pos brm_JHA <256 0 256 0>;\012    pos brm_NYA <173 0 173 0>;\012    pos brm_TTA <296 0 296 0>;\012    pos brm_DDHA <143 0 143 0>;\012    pos brm_NNA <159 0 159 0>;\012	pos brm_TA <135 0 135 0>;\012    pos brm_DA <246 0 246 0>;\012    pos brm_DHA <246 0 246 0>;\012	pos brm_shortE <246 0 246 0>;\012    pos brm_NA <199 0 199 0>;\012    pos brm_PA <321 0 321 0>;\012    pos brm_PHA <256 0 256 0>;\012    pos brm_BA <227 0 227 0>;\012    pos brm_MA <296 0 296 0>;\012	pos brm_YA <41 0 41 0>;\012    pos brm_RA <296 0 296 0>;\012    pos brm_VA <238 0 238 0>;\012	pos SA <56 0 56 0>;\012    pos brm_SHA <120 0 120 0>;\012    pos brm_SSA <256 0 256 0>;\012    pos brm_HA <256 0 256 0>;\012    pos brm_LLLA <207 0 207 0>;\012    pos brm_RRA <209 0 209 0>;\012	pos brm_RRAVirama <159 0 159 0>;\012    pos brm_NNNA <204 0 204 0>;\012    pos brm_JNYA <220 0 220 0>;\012} SinglePositioning45;\012";
+name = SinglePositioning45;
+},
+{
+code = "lookup ChainedContextualGPOS12 {\012    lookupflag 0;\012    ;\012\012	pos @class35 @class54' lookup SinglePositioning45 [brm_vowelShortE brm_vowelShortO];\012    pos @class37 @class54' lookup SinglePositioning45 [brm_vowelShortE brm_vowelShortO];\012    pos @class39 @class54' lookup SinglePositioning45 [brm_vowelShortE brm_vowelShortO];\012    pos @class41 @class54' lookup SinglePositioning45 [brm_vowelShortE brm_vowelShortO];\012	\012} ChainedContextualGPOS12;\012";
+name = ChainedContextualGPOS12;
+},
+{
+code = "lookup SinglePositioning44 {\012    lookupflag 0;\012    ;\012    # Original source: 30 \012    pos brm_GA <146 0 146 0>;\012    pos brm_GHA <146 0 146 0>;\012    pos brm_NGA <156 0 156 0>;\012    pos brm_CA <146 0 146 0>;\012    pos brm_CHA <146 0 146 0>;\012    pos brm_JA <137 0 137 0>;\012    pos brm_JHA <137 0 137 0>;\012    pos brm_NYA <43 0 43 0>;\012    pos brm_TTA <110 0 110 0>;\012    pos brm_DDA <110 0 110 0>;\012	pos brm_LLA <110 0 110 0>;\012    pos brm_DDHA <137 0 137 0>;\012    pos brm_NNA <30 0 30 0>;\012    pos brm_DA <137 0 137 0>;\012    pos brm_DHA <146 0 146 0>;\012	pos brm_shortE <146 0 146 0>;\012    pos brm_NA <30 0 30 0>;\012    pos brm_PA <171 0 171 0>;\012    pos brm_PHA <156 0 156 0>;\012    pos brm_BA <127 0 127 0>;\012    pos brm_BHA <127 0 127 0>;\012    pos brm_MA <98 0 98 0>;\012    pos brm_YA <146 0 146 0>;\012    pos brm_RA <146 0 146 0>;\012    pos brm_VA <110 0 110 0>;\012    pos brm_SHA <59 0 59 0>;\012    pos brm_SSA <156 0 156 0>;\012    pos brm_HA <156 0 156 0>;\012    pos brm_LLLA <107 0 107 0>;\012    pos brm_RRA <146 0 146 0>;\012	pos brm_RRAVirama <146 0 146 0>;\012    pos brm_NNNA <54 0 54 0>;\012    pos brm_VOCALIC_R <73 0 73 0>;\012    pos brm_VOCALIC_RR <73 0 73 0>;\012    pos brm_VOCALIC_R.alt2 <73 0 73 0>;\012    pos brm_VOCALIC_RR.alt2 <73 0 73 0>;\012} SinglePositioning44;\012";
 name = SinglePositioning44;
 },
 {
@@ -511,7 +560,7 @@ code = "lookup ChainedContextualGPOS8 {\012    lookupflag 0;\012    ;\012    # O
 name = ChainedContextualGPOS8;
 },
 {
-code = "lookup SinglePositioning41 {\012    lookupflag 0;\012    ;\012    # Original source: 27 \012    pos brm_A <49 0 49 0>;\012    pos brm_AA <49 0 49 0>;\012    pos brm_I <49 0 49 0>;\012    pos brm_II <49 0 49 0>;\012    pos brm_U <49 0 49 0>;\012    pos brm_UU <49 0 49 0>;\012    pos brm_R <49 0 49 0>;\012    pos brm_RR <49 0 49 0>;\012    pos brm_L <49 0 49 0>;\012    pos brm_LL <49 0 49 0>;\012    pos brm_E <49 0 49 0>;\012    pos brm_AI <49 0 49 0>;\012    pos brm_O <49 0 49 0>;\012    pos brm_AU <49 0 49 0>;\012    pos brm_KHA <49 0 49 0>;\012    pos brm_GA <49 0 49 0>;\012    pos brm_GHA <49 0 49 0>;\012    pos brm_NGA <49 0 49 0>;\012    pos brm_JA <49 0 49 0>;\012    pos brm_JHA <49 0 49 0>;\012    pos brm_NYA <49 0 49 0>;\012    pos brm_TTA <49 0 49 0>;\012    pos brm_TTHA <39 0 39 0>;\012    pos brm_DDA <49 0 49 0>;\012    pos brm_DDHA <49 0 49 0>;\012    pos brm_NNA <49 0 49 0>;\012    pos brm_THA <39 0 39 0>;\012    pos brm_DA <49 0 49 0>;\012    pos brm_DHA <49 0 49 0>;\012    pos brm_PA <49 0 49 0>;\012    pos brm_PHA <49 0 49 0>;\012    pos brm_BA <49 0 49 0>;\012    pos brm_MA <49 0 49 0>;\012    pos brm_RA <49 0 49 0>;\012    pos brm_VA <49 0 49 0>;\012    pos brm_SHA <49 0 49 0>;\012    pos brm_SSA <49 0 49 0>;\012    pos brm_HA <49 0 49 0>;\012    pos brm_RRA <49 0 49 0>;\012    pos brm_NNNA <49 0 49 0>;\012    pos brm_GHU <49 0 49 0>;\012    pos brm_GHUU <49 0 49 0>;\012    pos brm_NGU <49 0 49 0>;\012    pos brm_NGUU <49 0 49 0>;\012    pos brm_CU <49 0 49 0>;\012    pos brm_CUU <49 0 49 0>;\012    pos brm_CHU <49 0 49 0>;\012    pos brm_CHUU <49 0 49 0>;\012    pos brm_JAA <49 0 49 0>;\012    pos brm_JO <49 0 49 0>;\012    pos brm_JAU <49 0 49 0>;\012    pos brm_JU <49 0 49 0>;\012    pos brm_JUU <49 0 49 0>;\012    pos brm_JHO <49 0 49 0>;\012    pos brm_JHAU <49 0 49 0>;\012    pos brm_NYO <49 0 49 0>;\012    pos brm_NYAU <49 0 49 0>;\012    pos brm_TTU <49 0 49 0>;\012    pos brm_TTUU <49 0 49 0>;\012    pos brm_TTHO <49 0 49 0>;\012    pos brm_TTHAU <49 0 49 0>;\012    pos brm_TTHU <39 0 39 0>;\012    pos brm_TTHUU <39 0 39 0>;\012    pos brm_DDHU <49 0 49 0>;\012    pos brm_DDHUU <49 0 49 0>;\012    pos brm_NNU <49 0 49 0>;\012    pos brm_NNUU <49 0 49 0>;\012    pos brm_THO <49 0 49 0>;\012    pos brm_THAU <49 0 49 0>;\012    pos brm_THU <39 0 39 0>;\012    pos brm_THUU <39 0 39 0>;\012    pos brm_DHO <49 0 49 0>;\012    pos brm_DHAU <49 0 49 0>;\012    pos brm_NU <49 0 49 0>;\012    pos brm_NUU <49 0 49 0>;\012    pos brm_PU <49 0 49 0>;\012    pos brm_PUU <49 0 49 0>;\012    pos brm_PHU <49 0 49 0>;\012    pos brm_PHUU <49 0 49 0>;\012    pos brm_BO <49 0 49 0>;\012    pos brm_BAU <49 0 49 0>;\012    pos brm_BU <49 0 49 0>;\012    pos brm_BUU <49 0 49 0>;\012    pos brm_MO <49 0 49 0>;\012    pos brm_MAU <49 0 49 0>;\012    pos brm_MU <49 0 49 0>;\012    pos brm_MUU <49 0 49 0>;\012    pos brm_YU <49 0 49 0>;\012    pos brm_YUU <49 0 49 0>;\012    pos brm_LU <49 0 49 0>;\012    pos brm_LUU <49 0 49 0>;\012    pos brm_VU <49 0 49 0>;\012    pos brm_VUU <49 0 49 0>;\012    pos brm_SSU <49 0 49 0>;\012    pos brm_SSUU <49 0 49 0>;\012    pos brm_SU <49 0 49 0>;\012    pos brm_SUU <49 0 49 0>;\012    pos brm_HU <49 0 49 0>;\012    pos brm_HUU <49 0 49 0>;\012    pos brm_LLU <49 0 49 0>;\012    pos brm_LLUU <49 0 49 0>;\012    pos brm_LLLO <49 0 49 0>;\012    pos brm_LLLAU <49 0 49 0>;\012    pos brm_RRO <49 0 49 0>;\012    pos brm_RRAU <49 0 49 0>;\012    pos brm_NNNO <49 0 49 0>;\012    pos brm_NNNAU <49 0 49 0>;\012    pos brm_NNNU <49 0 49 0>;\012    pos brm_NNNUU <49 0 49 0>;\012    pos brm_SVA <49 0 49 0>;\012    pos brm_KSSA <49 0 49 0>;\012    pos brm_JNYA <49 0 49 0>;\012    pos brm_TTHEE <49 0 49 0>;\012    pos brm_TTHAI <49 0 49 0>;\012    pos brm_THEE <49 0 49 0>;\012    pos brm_THAI <49 0 49 0>;\012    pos brm_TTHR <49 0 49 0>;\012    pos brm_THR <49 0 49 0>;\012    pos brm_TTHRR <49 0 49 0>;\012    pos brm_THRR <49 0 49 0>;\012    pos brm_DAU <49 0 49 0>;\012    pos brm_DHU <49 0 49 0>;\012    pos brm_DHUU <49 0 49 0>;\012    pos brm_BHAU <49 0 49 0>;\012} SinglePositioning41;\012";
+code = "lookup SinglePositioning41 {\012    lookupflag 0;\012    ;\012    # Original source: 27 \012    pos brm_A <49 0 49 0>;\012    pos brm_AA <49 0 49 0>;\012    pos brm_I <49 0 49 0>;\012    pos brm_II <49 0 49 0>;\012    pos brm_U <49 0 49 0>;\012    pos brm_UU <49 0 49 0>;\012    pos brm_R <49 0 49 0>;\012    pos brm_RR <49 0 49 0>;\012    pos brm_L <49 0 49 0>;\012    pos brm_LL <49 0 49 0>;\012    pos brm_E <49 0 49 0>;\012    pos brm_AI <49 0 49 0>;\012    pos brm_O <49 0 49 0>;\012	pos brm_shortO <49 0 49 0>;\012    pos brm_AU <49 0 49 0>;\012    pos brm_KHA <49 0 49 0>;\012    pos brm_GA <49 0 49 0>;\012    pos brm_GHA <49 0 49 0>;\012    pos brm_NGA <49 0 49 0>;\012    pos brm_JA <49 0 49 0>;\012    pos brm_JHA <49 0 49 0>;\012    pos brm_NYA <49 0 49 0>;\012    pos brm_TTA <49 0 49 0>;\012    pos brm_TTHA <39 0 39 0>;\012    pos brm_DDA <49 0 49 0>;\012	pos brm_LLA <49 0 49 0>;\012    pos brm_DDHA <49 0 49 0>;\012    pos brm_NNA <49 0 49 0>;\012    pos brm_THA <39 0 39 0>;\012    pos brm_DA <49 0 49 0>;\012    pos brm_DHA <49 0 49 0>;\012	pos brm_shortE <49 0 49 0>;\012    pos brm_PA <49 0 49 0>;\012    pos brm_PHA <49 0 49 0>;\012    pos brm_BA <49 0 49 0>;\012    pos brm_MA <49 0 49 0>;\012    pos brm_RA <49 0 49 0>;\012    pos brm_VA <49 0 49 0>;\012    pos brm_SHA <49 0 49 0>;\012    pos brm_SSA <49 0 49 0>;\012    pos brm_HA <49 0 49 0>;\012    pos brm_RRA <49 0 49 0>;\012	pos brm_RRAVirama <49 0 49 0>;\012    pos brm_NNNA <49 0 49 0>;\012    pos brm_GHU <49 0 49 0>;\012    pos brm_GHUU <49 0 49 0>;\012    pos brm_NGU <49 0 49 0>;\012    pos brm_NGUU <49 0 49 0>;\012    pos brm_CU <49 0 49 0>;\012    pos brm_CUU <49 0 49 0>;\012    pos brm_CHU <49 0 49 0>;\012    pos brm_CHUU <49 0 49 0>;\012    pos brm_JAA <49 0 49 0>;\012    pos brm_JO <49 0 49 0>;\012    pos brm_JAU <49 0 49 0>;\012    pos brm_JU <49 0 49 0>;\012    pos brm_JUU <49 0 49 0>;\012    pos brm_JHO <49 0 49 0>;\012    pos brm_JHAU <49 0 49 0>;\012    pos brm_NYO <49 0 49 0>;\012	pos brm_NYAshortO <49 0 49 0>;\012    pos brm_NYAU <49 0 49 0>;\012    pos brm_TTU <49 0 49 0>;\012    pos brm_TTUU <49 0 49 0>;\012    pos brm_TTHO <49 0 49 0>;\012    pos brm_TTHAU <49 0 49 0>;\012    pos brm_TTHU <39 0 39 0>;\012    pos brm_TTHUU <39 0 39 0>;\012    pos brm_DDHU <49 0 49 0>;\012    pos brm_DDHUU <49 0 49 0>;\012    pos brm_NNU <49 0 49 0>;\012    pos brm_NNUU <49 0 49 0>;\012    pos brm_THO <49 0 49 0>;\012    pos brm_THAU <49 0 49 0>;\012    pos brm_THU <39 0 39 0>;\012    pos brm_THUU <39 0 39 0>;\012    pos brm_DHO <49 0 49 0>;\012	pos brm_DHAshortO <49 0 49 0>;\012    pos brm_DHAU <49 0 49 0>;\012    pos brm_NU <49 0 49 0>;\012    pos brm_NUU <49 0 49 0>;\012    pos brm_PU <49 0 49 0>;\012    pos brm_PUU <49 0 49 0>;\012    pos brm_PHU <49 0 49 0>;\012    pos brm_PHUU <49 0 49 0>;\012    pos brm_BO <49 0 49 0>;\012    pos brm_BAU <49 0 49 0>;\012    pos brm_BU <49 0 49 0>;\012    pos brm_BUU <49 0 49 0>;\012    pos brm_MO <49 0 49 0>;\012	pos brm_MAshortO <49 0 49 0>;\012    pos brm_MAU <49 0 49 0>;\012    pos brm_MU <49 0 49 0>;\012    pos brm_MUU <49 0 49 0>;\012    pos brm_YU <49 0 49 0>;\012    pos brm_YUU <49 0 49 0>;\012    pos brm_LU <49 0 49 0>;\012    pos brm_LUU <49 0 49 0>;\012    pos brm_VU <49 0 49 0>;\012    pos brm_VUU <49 0 49 0>;\012    pos brm_SSU <49 0 49 0>;\012    pos brm_SSUU <49 0 49 0>;\012    pos brm_SU <49 0 49 0>;\012    pos brm_SUU <49 0 49 0>;\012    pos brm_HU <49 0 49 0>;\012    pos brm_HUU <49 0 49 0>;\012    pos brm_LLU <49 0 49 0>;\012    pos brm_LLUU <49 0 49 0>;\012    pos brm_LLLO <49 0 49 0>;\012	pos brm_LLLAshortO <49 0 49 0>;\012    pos brm_LLLAU <49 0 49 0>;\012    pos brm_RRO <49 0 49 0>;\012	pos brm_RRAshortO <49 0 49 0>;\012    pos brm_RRAU <49 0 49 0>;\012    pos brm_NNNO <49 0 49 0>;\012	pos brm_NNNAshortO <49 0 49 0>;\012    pos brm_NNNAU <49 0 49 0>;\012    pos brm_NNNU <49 0 49 0>;\012    pos brm_NNNUU <49 0 49 0>;\012    pos brm_SVA <49 0 49 0>;\012    pos brm_KSSA <49 0 49 0>;\012    pos brm_JNYA <49 0 49 0>;\012    pos brm_TTHEE <49 0 49 0>;\012    pos brm_TTHAI <49 0 49 0>;\012    pos brm_THEE <49 0 49 0>;\012    pos brm_THAI <49 0 49 0>;\012    pos brm_TTHR <49 0 49 0>;\012    pos brm_THR <49 0 49 0>;\012    pos brm_TTHRR <49 0 49 0>;\012    pos brm_THRR <49 0 49 0>;\012    pos brm_DAU <49 0 49 0>;\012    pos brm_DHU <49 0 49 0>;\012    pos brm_DHUU <49 0 49 0>;\012    pos brm_BHAU <49 0 49 0>;\012} SinglePositioning41;\012";
 name = SinglePositioning41;
 },
 {
@@ -519,11 +568,11 @@ code = "lookup ChainedContextualGPOS9 {\012    lookupflag 0;\012    ;\012    # O
 name = ChainedContextualGPOS9;
 },
 {
-code = "lookup SinglePositioning42 {\012    lookupflag 0;\012    ;\012    # Original source: 28 \012    pos brm_A <146 0 146 0>;\012    pos brm_AA <146 0 146 0>;\012    pos brm_I <146 0 146 0>;\012    pos brm_II <146 0 146 0>;\012    pos brm_U <146 0 146 0>;\012    pos brm_UU <146 0 146 0>;\012    pos brm_R <146 0 146 0>;\012    pos brm_RR <146 0 146 0>;\012    pos brm_L <146 0 146 0>;\012    pos brm_LL <146 0 146 0>;\012    pos brm_E <146 0 146 0>;\012    pos brm_AI <146 0 146 0>;\012    pos brm_O <146 0 146 0>;\012    pos brm_AU <146 0 146 0>;\012    pos brm_KHA <146 0 146 0>;\012    pos brm_GA <146 0 146 0>;\012    pos brm_GHA <146 0 146 0>;\012    pos brm_NGA <146 0 146 0>;\012    pos brm_JA <146 0 146 0>;\012    pos brm_JHA <146 0 146 0>;\012    pos brm_NYA <146 0 146 0>;\012    pos brm_TTA <146 0 146 0>;\012    pos brm_TTHA <73 0 73 0>;\012    pos brm_DDA <146 0 146 0>;\012    pos brm_DDHA <146 0 146 0>;\012    pos brm_NNA <146 0 146 0>;\012    pos brm_THA <73 0 73 0>;\012    pos brm_DA <146 0 146 0>;\012    pos brm_DHA <146 0 146 0>;\012    pos brm_PA <146 0 146 0>;\012    pos brm_PHA <146 0 146 0>;\012    pos brm_BA <146 0 146 0>;\012    pos brm_MA <146 0 146 0>;\012    pos brm_RA <146 0 146 0>;\012    pos brm_VA <146 0 146 0>;\012    pos brm_SHA <146 0 146 0>;\012    pos brm_SSA <146 0 146 0>;\012    pos brm_HA <146 0 146 0>;\012    pos brm_RRA <146 0 146 0>;\012    pos brm_NNNA <146 0 146 0>;\012    pos brm_GHU <146 0 146 0>;\012    pos brm_GHUU <146 0 146 0>;\012    pos brm_NGU <146 0 146 0>;\012    pos brm_NGUU <146 0 146 0>;\012    pos brm_CU <146 0 146 0>;\012    pos brm_CUU <146 0 146 0>;\012    pos brm_CHU <146 0 146 0>;\012    pos brm_CHUU <146 0 146 0>;\012    pos brm_JAA <146 0 146 0>;\012    pos brm_JO <146 0 146 0>;\012    pos brm_JAU <146 0 146 0>;\012    pos brm_JU <146 0 146 0>;\012    pos brm_JUU <146 0 146 0>;\012    pos brm_JHO <146 0 146 0>;\012    pos brm_JHAU <146 0 146 0>;\012    pos brm_NYO <146 0 146 0>;\012    pos brm_NYAU <146 0 146 0>;\012    pos brm_TTU <146 0 146 0>;\012    pos brm_TTUU <146 0 146 0>;\012    pos brm_TTHO <146 0 146 0>;\012    pos brm_TTHAU <146 0 146 0>;\012    pos brm_TTHU <73 0 73 0>;\012    pos brm_TTHUU <73 0 73 0>;\012    pos brm_DDHU <146 0 146 0>;\012    pos brm_DDHUU <146 0 146 0>;\012    pos brm_NNU <146 0 146 0>;\012    pos brm_NNUU <146 0 146 0>;\012    pos brm_THO <146 0 146 0>;\012    pos brm_THAU <146 0 146 0>;\012    pos brm_THU <73 0 73 0>;\012    pos brm_THUU <73 0 73 0>;\012    pos brm_DHO <146 0 146 0>;\012    pos brm_DHAU <146 0 146 0>;\012    pos brm_NU <146 0 146 0>;\012    pos brm_NUU <146 0 146 0>;\012    pos brm_PU <146 0 146 0>;\012    pos brm_PUU <146 0 146 0>;\012    pos brm_PHU <146 0 146 0>;\012    pos brm_PHUU <146 0 146 0>;\012    pos brm_BO <146 0 146 0>;\012    pos brm_BAU <146 0 146 0>;\012    pos brm_BU <146 0 146 0>;\012    pos brm_BUU <146 0 146 0>;\012    pos brm_MO <146 0 146 0>;\012    pos brm_MAU <146 0 146 0>;\012    pos brm_MU <146 0 146 0>;\012    pos brm_MUU <146 0 146 0>;\012    pos brm_YU <146 0 146 0>;\012    pos brm_YUU <146 0 146 0>;\012    pos brm_LU <146 0 146 0>;\012    pos brm_LUU <146 0 146 0>;\012    pos brm_VU <146 0 146 0>;\012    pos brm_VUU <146 0 146 0>;\012    pos brm_SSU <146 0 146 0>;\012    pos brm_SSUU <146 0 146 0>;\012    pos brm_SU <146 0 146 0>;\012    pos brm_SUU <146 0 146 0>;\012    pos brm_HU <146 0 146 0>;\012    pos brm_HUU <146 0 146 0>;\012    pos brm_LLU <146 0 146 0>;\012    pos brm_LLUU <146 0 146 0>;\012    pos brm_LLLO <146 0 146 0>;\012    pos brm_LLLAU <146 0 146 0>;\012    pos brm_RRO <146 0 146 0>;\012    pos brm_RRAU <146 0 146 0>;\012    pos brm_NNNO <146 0 146 0>;\012    pos brm_NNNAU <146 0 146 0>;\012    pos brm_NNNU <146 0 146 0>;\012    pos brm_NNNUU <146 0 146 0>;\012    pos brm_SVA <146 0 146 0>;\012    pos brm_KSSA <146 0 146 0>;\012    pos brm_JNYA <146 0 146 0>;\012    pos brm_TTHEE <146 0 146 0>;\012    pos brm_TTHAI <146 0 146 0>;\012    pos brm_THEE <146 0 146 0>;\012    pos brm_THAI <146 0 146 0>;\012    pos brm_TTHR <73 0 73 0>;\012    pos brm_THR <73 0 73 0>;\012    pos brm_TTHRR <73 0 73 0>;\012    pos brm_THRR <73 0 73 0>;\012    pos brm_DAU <146 0 146 0>;\012    pos brm_DHU <146 0 146 0>;\012    pos brm_DHUU <146 0 146 0>;\012    pos brm_BHAU <146 0 146 0>;\012    pos brm_TRR <49 0 49 0>;\012    pos brm_TUU <49 0 49 0>;\012} SinglePositioning42;\012";
+code = "lookup SinglePositioning42 {\012    lookupflag 0;\012    ;\012    # Original source: 28 \012    pos brm_A <146 0 146 0>;\012    pos brm_AA <146 0 146 0>;\012    pos brm_I <146 0 146 0>;\012    pos brm_II <146 0 146 0>;\012    pos brm_U <146 0 146 0>;\012    pos brm_UU <146 0 146 0>;\012    pos brm_R <146 0 146 0>;\012    pos brm_RR <146 0 146 0>;\012    pos brm_L <146 0 146 0>;\012    pos brm_LL <146 0 146 0>;\012    pos brm_E <146 0 146 0>;\012    pos brm_AI <146 0 146 0>;\012    pos brm_O <146 0 146 0>;\012	pos brm_shortO <146 0 146 0>;\012    pos brm_AU <146 0 146 0>;\012    pos brm_KHA <146 0 146 0>;\012    pos brm_GA <146 0 146 0>;\012    pos brm_GHA <146 0 146 0>;\012    pos brm_NGA <146 0 146 0>;\012    pos brm_JA <146 0 146 0>;\012    pos brm_JHA <146 0 146 0>;\012    pos brm_NYA <146 0 146 0>;\012    pos brm_TTA <146 0 146 0>;\012    pos brm_TTHA <73 0 73 0>;\012    pos brm_DDA <146 0 146 0>;\012	pos brm_LLA <146 0 146 0>;\012    pos brm_DDHA <146 0 146 0>;\012    pos brm_NNA <146 0 146 0>;\012    pos brm_THA <73 0 73 0>;\012    pos brm_DA <146 0 146 0>;\012    pos brm_DHA <146 0 146 0>;\012	pos brm_shortE <146 0 146 0>;\012    pos brm_PA <146 0 146 0>;\012    pos brm_PHA <146 0 146 0>;\012    pos brm_BA <146 0 146 0>;\012    pos brm_MA <146 0 146 0>;\012    pos brm_RA <146 0 146 0>;\012    pos brm_VA <146 0 146 0>;\012    pos brm_SHA <146 0 146 0>;\012    pos brm_SSA <146 0 146 0>;\012    pos brm_HA <146 0 146 0>;\012    pos brm_RRA <146 0 146 0>;\012	pos brm_RRAVirama <146 0 146 0>;\012    pos brm_NNNA <146 0 146 0>;\012    pos brm_GHU <146 0 146 0>;\012    pos brm_GHUU <146 0 146 0>;\012    pos brm_NGU <146 0 146 0>;\012    pos brm_NGUU <146 0 146 0>;\012    pos brm_CU <146 0 146 0>;\012    pos brm_CUU <146 0 146 0>;\012    pos brm_CHU <146 0 146 0>;\012    pos brm_CHUU <146 0 146 0>;\012    pos brm_JAA <146 0 146 0>;\012    pos brm_JO <146 0 146 0>;\012    pos brm_JAU <146 0 146 0>;\012    pos brm_JU <146 0 146 0>;\012    pos brm_JUU <146 0 146 0>;\012    pos brm_JHO <146 0 146 0>;\012    pos brm_JHAU <146 0 146 0>;\012    pos brm_NYO <146 0 146 0>;\012	pos brm_NYAshortO <146 0 146 0>;\012    pos brm_NYAU <146 0 146 0>;\012    pos brm_TTU <146 0 146 0>;\012    pos brm_TTUU <146 0 146 0>;\012    pos brm_TTHO <146 0 146 0>;\012    pos brm_TTHAU <146 0 146 0>;\012    pos brm_TTHU <73 0 73 0>;\012    pos brm_TTHUU <73 0 73 0>;\012    pos brm_DDHU <146 0 146 0>;\012    pos brm_DDHUU <146 0 146 0>;\012    pos brm_NNU <146 0 146 0>;\012    pos brm_NNUU <146 0 146 0>;\012    pos brm_THO <146 0 146 0>;\012    pos brm_THAU <146 0 146 0>;\012    pos brm_THU <73 0 73 0>;\012    pos brm_THUU <73 0 73 0>;\012    pos brm_DHO <146 0 146 0>;\012	pos brm_DHAshortO <146 0 146 0>;\012    pos brm_DHAU <146 0 146 0>;\012    pos brm_NU <146 0 146 0>;\012    pos brm_NUU <146 0 146 0>;\012    pos brm_PU <146 0 146 0>;\012    pos brm_PUU <146 0 146 0>;\012    pos brm_PHU <146 0 146 0>;\012    pos brm_PHUU <146 0 146 0>;\012    pos brm_BO <146 0 146 0>;\012    pos brm_BAU <146 0 146 0>;\012    pos brm_BU <146 0 146 0>;\012    pos brm_BUU <146 0 146 0>;\012    pos brm_MO <146 0 146 0>;\012	pos brm_MAshortO <146 0 146 0>;\012    pos brm_MAU <146 0 146 0>;\012    pos brm_MU <146 0 146 0>;\012    pos brm_MUU <146 0 146 0>;\012    pos brm_YU <146 0 146 0>;\012    pos brm_YUU <146 0 146 0>;\012    pos brm_LU <146 0 146 0>;\012    pos brm_LUU <146 0 146 0>;\012    pos brm_VU <146 0 146 0>;\012    pos brm_VUU <146 0 146 0>;\012    pos brm_SSU <146 0 146 0>;\012    pos brm_SSUU <146 0 146 0>;\012    pos brm_SU <146 0 146 0>;\012    pos brm_SUU <146 0 146 0>;\012    pos brm_HU <146 0 146 0>;\012    pos brm_HUU <146 0 146 0>;\012    pos brm_LLU <146 0 146 0>;\012    pos brm_LLUU <146 0 146 0>;\012    pos brm_LLLO <146 0 146 0>;\012	pos brm_LLLAshortO <146 0 146 0>;\012    pos brm_LLLAU <146 0 146 0>;\012    pos brm_RRO <146 0 146 0>;\012	pos brm_RRAshortO <146 0 146 0>;\012    pos brm_RRAU <146 0 146 0>;\012    pos brm_NNNO <146 0 146 0>;\012	pos brm_NNNAshortO <146 0 146 0>;\012    pos brm_NNNAU <146 0 146 0>;\012    pos brm_NNNU <146 0 146 0>;\012    pos brm_NNNUU <146 0 146 0>;\012    pos brm_SVA <146 0 146 0>;\012    pos brm_KSSA <146 0 146 0>;\012    pos brm_JNYA <146 0 146 0>;\012    pos brm_TTHEE <146 0 146 0>;\012    pos brm_TTHAI <146 0 146 0>;\012    pos brm_THEE <146 0 146 0>;\012    pos brm_THAI <146 0 146 0>;\012    pos brm_TTHR <73 0 73 0>;\012    pos brm_THR <73 0 73 0>;\012    pos brm_TTHRR <73 0 73 0>;\012    pos brm_THRR <73 0 73 0>;\012    pos brm_DAU <146 0 146 0>;\012    pos brm_DHU <146 0 146 0>;\012    pos brm_DHUU <146 0 146 0>;\012    pos brm_BHAU <146 0 146 0>;\012    pos brm_TRR <49 0 49 0>;\012    pos brm_TUU <49 0 49 0>;\012} SinglePositioning42;\012";
 name = SinglePositioning42;
 },
 {
-code = "lookup ChainedContextualGPOS10 {\012    lookupflag 0;\012    ;\012    # Original source: 9 \012    pos brm_BHA brm_vowelOO @class51' lookup SinglePositioning42;\012} ChainedContextualGPOS10;\012";
+code = "lookup ChainedContextualGPOS10 {\012    lookupflag 0;\012    ;\012    # Original source: 9 \012    pos brm_BHA [brm_vowelOO brm_vowelShortO] @class51' lookup SinglePositioning42;\012} ChainedContextualGPOS10;\012";
 name = ChainedContextualGPOS10;
 },
 {
@@ -545,7 +594,7 @@ code = "    lookup LigatureSubstitution1;\012\012    lookup LigatureSubstitution
 name = ccmp;
 },
 {
-code = "# Automatic Code Start\012    lookup ChainedContextualGPOS1;\012\012    lookup ChainedContextualGPOS2;\012\012    lookup ChainedContextualGPOS3;\012\012    lookup ChainedContextualGPOS4;\012\012    lookup ChainedContextualGPOS5;\012\012    lookup ChainedContextualGPOS6;\012\012    lookup ChainedContextualGPOS7;\012\012    lookup ChainedContextualGPOS9;\012\012    lookup ChainedContextualGPOS10;\012\012    lookup ChainedContextualGPOS11;\012\012    lookup ChainedContextualGPOS8;\012";
+code = "# Automatic Code Start\012\012    lookup ChainedContextualGPOS1;\012\012    lookup ChainedContextualGPOS2;\012\012    lookup ChainedContextualGPOS3;\012\012    lookup ChainedContextualGPOS4;\012\012    lookup ChainedContextualGPOS5;\012\012    lookup ChainedContextualGPOS6;\012\012    lookup ChainedContextualGPOS7;\012\012	lookup ChainedContextualGPOS12;\012\012    lookup ChainedContextualGPOS9;\012\012    lookup ChainedContextualGPOS10;\012\012    lookup ChainedContextualGPOS11;\012\012    lookup ChainedContextualGPOS8;\012";
 name = dist;
 },
 {
@@ -565,7 +614,7 @@ code = "# Automatic Code Start\012";
 name = mkmk;
 },
 {
-code = "lookup PairPositioning27 {\012    lookupflag 0;\012    ;\012    # Original source: 16 \012    pos brm_TTA <NULL> brm_VOCALIC_R.alt2 <100 0 0 0>;\012    pos brm_DA <NULL> brm_VOCALIC_RR.alt <0 189 0 0>;\012    pos brm_LA <NULL> brm_VOCALIC_R.alt2 <-20 -80 0 0>;\012    pos SA <NULL> brm_VOCALIC_R.alt2 <0 -80 0 0>;\012    pos brm_LLA <NULL> brm_VOCALIC_R.alt2 <-20 -80 0 0>;\012    pos brm_LLLA <NULL> brm_VOCALIC_RR <0 23 0 0>;\012    pos brm_JNYA <NULL> brm_vowelU <0 -80 0 0>;\012} PairPositioning27;\012\012# Add air to base + vocalic R, see #6\012pos @class15 <150 0 150 0> brm_VOCALIC_R;\012";
+code = "lookup PairPositioning27 {\012    lookupflag 0;\012    ;\012    # Original source: 16 \012    pos brm_TTA <NULL> brm_VOCALIC_R.alt2 <100 0 0 0>;\012    pos brm_DA <NULL> brm_VOCALIC_RR.alt <0 189 0 0>;\012    pos brm_LA <NULL> brm_VOCALIC_R.alt2 <-20 -80 0 0>;\012    pos SA <NULL> brm_VOCALIC_R.alt2 <0 -80 0 0>;\012    pos brm_OldTamilLLA <NULL> brm_VOCALIC_R.alt2 <-20 -80 0 0>;\012    pos brm_LLLA <NULL> brm_VOCALIC_RR <0 23 0 0>;\012    pos brm_JNYA <NULL> brm_vowelU <0 -80 0 0>;\012} PairPositioning27;\012\012# Add air to base + vocalic R, see #6\012pos @class15 <150 0 150 0> brm_VOCALIC_R;\012\012# kerning Old Tamil Virama with base glyphs\012pos uni25CC <NULL> brm_OldTamilVirama <-40 0 -40 0>;\012pos brm_VA <NULL> brm_OldTamilVirama <-120 0 -120 0>;\012pos brm_LLLA <NULL> brm_OldTamilVirama <20 0 20 0>;\012pos brm_SHA <NULL> brm_OldTamilVirama <-130 0 -130 0>;\012pos brm_DHA <NULL> brm_OldTamilVirama <-20 0 -20 0>;\012pos brm_TA <NULL> brm_OldTamilVirama <-151 0 -151 0>;\012pos brm_NA <NULL> brm_OldTamilVirama <-107 0 -107 0>;\012";
 name = kern;
 }
 );
@@ -638,7 +687,7 @@ xHeight = 536;
 glyphs = (
 {
 glyphname = .notdef;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -668,7 +717,7 @@ width = 600;
 },
 {
 glyphname = NULL;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -679,7 +728,7 @@ unicode = 0000;
 },
 {
 glyphname = CR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -690,7 +739,7 @@ unicode = 000D;
 },
 {
 glyphname = space;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -701,7 +750,7 @@ unicode = 0020;
 },
 {
 glyphname = uni00A0;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -712,7 +761,7 @@ unicode = 00A0;
 },
 {
 glyphname = uni200B;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -724,7 +773,7 @@ unicode = 200B;
 },
 {
 glyphname = uni200C;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -736,7 +785,7 @@ unicode = 200C;
 },
 {
 glyphname = uni200D;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -747,7 +796,7 @@ unicode = 200D;
 },
 {
 glyphname = candrabindu;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -778,7 +827,7 @@ category = Letter;
 },
 {
 glyphname = anusvara;
-lastChange = "2021-12-13 13:56:05 +0000";
+lastChange = "2023-06-27 13:26:38 +0000";
 layers = (
 {
 anchors = (
@@ -824,7 +873,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = visarga;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -872,7 +921,7 @@ category = Letter;
 },
 {
 glyphname = u11003;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -913,7 +962,7 @@ category = Letter;
 },
 {
 glyphname = u11004;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -996,7 +1045,7 @@ category = Letter;
 },
 {
 glyphname = brm_A;
-lastChange = "2021-12-13 14:35:13 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1047,7 +1096,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_AA;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1101,7 +1150,7 @@ category = Letter;
 },
 {
 glyphname = brm_I;
-lastChange = "2021-12-13 14:35:49 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1173,7 +1222,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_II;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1236,7 +1285,7 @@ category = Letter;
 },
 {
 glyphname = brm_U;
-lastChange = "2021-12-13 14:35:21 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1272,7 +1321,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_UU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1311,7 +1360,7 @@ category = Letter;
 },
 {
 glyphname = brm_R;
-lastChange = "2021-12-13 14:13:37 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1353,7 +1402,7 @@ subCategory = Spacing;
 },
 {
 glyphname = brm_RR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1406,7 +1455,7 @@ category = Letter;
 },
 {
 glyphname = brm_L;
-lastChange = "2021-12-13 14:35:58 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1476,7 +1525,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_LL;
-lastChange = "2021-12-13 14:36:02 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1552,7 +1601,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_E;
-lastChange = "2021-12-13 14:36:08 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1590,7 +1639,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_AI;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1629,7 +1678,7 @@ category = Letter;
 },
 {
 glyphname = brm_O;
-lastChange = "2021-12-13 14:36:15 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1667,7 +1716,7 @@ subCategory = Other;
 },
 {
 glyphname = brm_AU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1708,7 +1757,7 @@ category = Letter;
 },
 {
 glyphname = brm_KA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-27 13:32:49 +0000";
 layers = (
 {
 anchors = (
@@ -1751,6 +1800,10 @@ position = "{375, 786}";
 {
 name = topleft;
 position = "{341, 717}";
+},
+{
+name = viramatm;
+position = "{559, 480}";
 }
 );
 layerId = UUID0;
@@ -1781,7 +1834,7 @@ category = Letter;
 },
 {
 glyphname = brm_KHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1859,7 +1912,7 @@ category = Letter;
 },
 {
 glyphname = brm_GA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -1923,7 +1976,7 @@ category = Letter;
 },
 {
 glyphname = brm_GHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2008,7 +2061,7 @@ category = Letter;
 },
 {
 glyphname = brm_NGA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2051,6 +2104,10 @@ position = "{268, 786}";
 {
 name = topleft;
 position = "{156, 717}";
+},
+{
+name = viramatm;
+position = "{353, 314}";
 }
 );
 layerId = UUID0;
@@ -2077,7 +2134,7 @@ category = Letter;
 },
 {
 glyphname = brm_CA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2160,7 +2217,7 @@ category = Letter;
 },
 {
 glyphname = brm_CHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2260,7 +2317,7 @@ category = Letter;
 },
 {
 glyphname = brm_JA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2350,7 +2407,7 @@ category = Letter;
 },
 {
 glyphname = brm_JHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2427,7 +2484,7 @@ category = Letter;
 },
 {
 glyphname = brm_NYA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-28 09:16:08 +0000";
 layers = (
 {
 anchors = (
@@ -2437,7 +2494,7 @@ position = "{244, 644}";
 },
 {
 name = ai;
-position = "{229, 501}";
+position = "{229, 431}";
 },
 {
 name = au;
@@ -2470,6 +2527,10 @@ position = "{341, 786}";
 {
 name = topleft;
 position = "{244, 717}";
+},
+{
+name = viramatm;
+position = "{412, 568}";
 }
 );
 layerId = UUID0;
@@ -2510,7 +2571,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2553,6 +2614,10 @@ position = "{292, 786}";
 {
 name = topleft;
 position = "{346, 717}";
+},
+{
+name = viramatm;
+position = "{353, 314}";
 }
 );
 layerId = UUID0;
@@ -2589,7 +2654,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2671,7 +2736,7 @@ category = Letter;
 },
 {
 glyphname = brm_DDA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2736,7 +2801,7 @@ category = Letter;
 },
 {
 glyphname = brm_DDHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -2832,7 +2897,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-28 08:16:31 +0000";
 layers = (
 {
 anchors = (
@@ -2875,6 +2940,10 @@ position = "{273, 786}";
 {
 name = topleft;
 position = "{224, 717}";
+},
+{
+name = viramatm;
+position = "{432, 314}";
 }
 );
 layerId = UUID0;
@@ -2905,7 +2974,7 @@ category = Letter;
 },
 {
 glyphname = brm_TA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-27 13:33:10 +0000";
 layers = (
 {
 anchors = (
@@ -2975,7 +3044,7 @@ category = Letter;
 },
 {
 glyphname = brm_THA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3074,7 +3143,7 @@ category = Letter;
 },
 {
 glyphname = brm_DA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3158,7 +3227,7 @@ category = Letter;
 },
 {
 glyphname = brm_DHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-27 13:34:21 +0000";
 layers = (
 {
 anchors = (
@@ -3237,7 +3306,7 @@ category = Letter;
 },
 {
 glyphname = brm_NA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-27 13:33:26 +0000";
 layers = (
 {
 anchors = (
@@ -3306,7 +3375,7 @@ category = Letter;
 },
 {
 glyphname = brm_PA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3349,6 +3418,10 @@ position = "{146, 786}";
 {
 name = topleft;
 position = "{102, 717}";
+},
+{
+name = viramatm;
+position = "{353, 480}";
 }
 );
 layerId = UUID0;
@@ -3385,7 +3458,7 @@ category = Letter;
 },
 {
 glyphname = brm_PHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3474,7 +3547,7 @@ category = Letter;
 },
 {
 glyphname = brm_BA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3504,7 +3577,7 @@ position = "{585, 78}";
 },
 {
 name = ee_oo;
-position = "{175, 656}";
+position = "{175, 655}";
 },
 {
 name = top;
@@ -3512,7 +3585,7 @@ position = "{375, 786}";
 },
 {
 name = topleft;
-position = "{166, 656}";
+position = "{166, 655}";
 }
 );
 layerId = UUID0;
@@ -3544,7 +3617,7 @@ category = Letter;
 },
 {
 glyphname = brm_BHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3617,7 +3690,7 @@ category = Letter;
 },
 {
 glyphname = brm_MA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3721,7 +3794,7 @@ category = Letter;
 },
 {
 glyphname = brm_YA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3764,6 +3837,10 @@ position = "{400, 786}";
 {
 name = topleft;
 position = "{371, 717}";
+},
+{
+name = viramatm;
+position = "{617, 480}";
 }
 );
 layerId = UUID0;
@@ -3815,7 +3892,7 @@ category = Letter;
 },
 {
 glyphname = brm_RA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3876,7 +3953,7 @@ category = Letter;
 },
 {
 glyphname = brm_LA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -3952,7 +4029,7 @@ category = Letter;
 },
 {
 glyphname = brm_VA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4045,7 +4122,7 @@ category = Letter;
 },
 {
 glyphname = brm_SHA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4114,7 +4191,7 @@ category = Letter;
 },
 {
 glyphname = brm_SSA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4197,7 +4274,7 @@ category = Letter;
 },
 {
 glyphname = SA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4240,6 +4317,10 @@ position = "{400, 786}";
 {
 name = topleft;
 position = "{361, 717}";
+},
+{
+name = viramatm;
+position = "{598, 480}";
 }
 );
 layerId = UUID0;
@@ -4292,7 +4373,7 @@ category = Letter;
 },
 {
 glyphname = brm_HA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4371,49 +4452,45 @@ category = Letter;
 },
 {
 glyphname = brm_LLA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
 {
 name = aa;
-position = "{595, 717}";
+position = "{332, 717}";
 },
 {
 name = ai;
-position = "{590, 591}";
+position = "{361, 591}";
 },
 {
 name = au;
-position = "{590, 593}";
+position = "{380, 593}";
 },
 {
 name = bottom;
-position = "{429, 0}";
+position = "{263, 0}";
 },
 {
 name = bottomleft;
-position = "{320, 80}";
+position = "{156, 0}";
 },
 {
 name = bottomright;
-position = "{478, 0}";
-},
-{
-name = center;
-position = "{693, 478}";
+position = "{116, 0}";
 },
 {
 name = ee_oo;
-position = "{590, 717}";
+position = "{380, 717}";
 },
 {
 name = top;
-position = "{590, 786}";
+position = "{356, 786}";
 },
 {
 name = topleft;
-position = "{595, 717}";
+position = "{332, 717}";
 }
 );
 layerId = UUID0;
@@ -4421,44 +4498,35 @@ paths = (
 {
 closed = 1;
 nodes = (
-"587 -12 OFFCURVE",
-"635 77 OFFCURVE",
-"635 252 CURVE SMOOTH",
-"635 266 LINE",
-"654 272 OFFCURVE",
-"676 275 OFFCURVE",
-"701 275 CURVE SMOOTH",
-"788 275 OFFCURVE",
-"821 237 OFFCURVE",
-"821 146 CURVE SMOOTH",
-"821 0 LINE",
-"911 0 LINE",
-"911 163 LINE SMOOTH",
-"911 300 OFFCURVE",
-"842 359 OFFCURVE",
-"711 359 CURVE SMOOTH",
-"684 359 OFFCURVE",
-"659 355 OFFCURVE",
-"635 347 CURVE",
-"635 714 LINE",
-"545 714 LINE",
-"545 247 LINE SMOOTH",
-"545 130 OFFCURVE",
-"524 72 OFFCURVE",
-"428 72 CURVE SMOOTH",
-"327 72 OFFCURVE",
-"292 107 OFFCURVE",
-"291 255 CURVE",
-"49 255 LINE",
-"49 175 LINE",
-"205 175 LINE",
-"220 44 OFFCURVE",
-"288 -12 OFFCURVE",
-"421 -12 CURVE SMOOTH"
+"407 332 LINE",
+"407 714 LINE",
+"317 714 LINE",
+"317 412 LINE",
+"78 412 LINE",
+"78 63 LINE",
+"168 63 LINE",
+"168 332 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 18 OFFCURVE",
+"78 -14 OFFCURVE",
+"122 -14 CURVE SMOOTH",
+"168 -14 OFFCURVE",
+"199 18 OFFCURVE",
+"199 63 CURVE SMOOTH",
+"199 109 OFFCURVE",
+"168 141 OFFCURVE",
+"122 141 CURVE SMOOTH",
+"78 141 OFFCURVE",
+"48 109 OFFCURVE",
+"48 63 CURVE SMOOTH"
 );
 }
 );
-width = 989;
+width = 485;
 }
 );
 unicode = 11034;
@@ -4466,7 +4534,7 @@ category = Letter;
 },
 {
 glyphname = brm_LLLA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4566,7 +4634,7 @@ category = Letter;
 },
 {
 glyphname = brm_RRA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4658,7 +4726,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNNA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4737,7 +4805,7 @@ category = Letter;
 },
 {
 glyphname = brm_vowelAA;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4771,7 +4839,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelBHATTIPROLUAA;
-lastChange = "2023-03-23 14:10:40 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4807,7 +4875,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelI;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4843,7 +4911,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelII;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4883,7 +4951,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4913,7 +4981,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4952,7 +5020,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_R;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -4982,7 +5050,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_RR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5021,7 +5089,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_L;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5091,7 +5159,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_LL;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5164,7 +5232,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelEE;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5198,7 +5266,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelAI;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5241,7 +5309,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelOO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5284,7 +5352,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5336,7 +5404,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_virama;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -5366,7 +5434,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_danda;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5389,7 +5457,7 @@ category = Letter;
 },
 {
 glyphname = brm_doubledanda;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5421,7 +5489,7 @@ category = Letter;
 },
 {
 glyphname = brm_punctDOT;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5444,7 +5512,7 @@ category = Letter;
 },
 {
 glyphname = brm_punctDBLDOT;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5476,7 +5544,7 @@ category = Letter;
 },
 {
 glyphname = brm_punctLINE;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5499,7 +5567,7 @@ category = Letter;
 },
 {
 glyphname = brm_punctBAR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5550,7 +5618,7 @@ category = Letter;
 },
 {
 glyphname = brm_Lotus;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -5979,7 +6047,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1;
-lastChange = "2023-03-23 14:01:30 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6032,7 +6100,7 @@ category = Letter;
 },
 {
 glyphname = brm_num2;
-lastChange = "2023-03-23 14:01:37 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6094,7 +6162,7 @@ category = Letter;
 },
 {
 glyphname = brm_num3;
-lastChange = "2023-03-23 14:01:45 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6165,7 +6233,7 @@ category = Letter;
 },
 {
 glyphname = brm_num4;
-lastChange = "2023-03-23 14:01:22 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6226,7 +6294,7 @@ category = Letter;
 },
 {
 glyphname = brm_num5;
-lastChange = "2023-03-23 14:01:53 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6295,7 +6363,7 @@ category = Letter;
 },
 {
 glyphname = brm_num6;
-lastChange = "2023-03-23 14:01:57 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6388,7 +6456,7 @@ category = Letter;
 },
 {
 glyphname = brm_num7;
-lastChange = "2023-03-23 14:02:03 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6465,7 +6533,7 @@ category = Letter;
 },
 {
 glyphname = brm_num8;
-lastChange = "2023-03-23 14:02:09 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6540,7 +6608,7 @@ category = Letter;
 },
 {
 glyphname = brm_num9;
-lastChange = "2023-03-23 14:02:18 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6613,7 +6681,7 @@ category = Letter;
 },
 {
 glyphname = brm_num10;
-lastChange = "2023-03-23 14:02:27 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6705,7 +6773,7 @@ category = Letter;
 },
 {
 glyphname = brm_num20;
-lastChange = "2023-03-23 14:02:32 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6790,7 +6858,7 @@ category = Letter;
 },
 {
 glyphname = brm_num30;
-lastChange = "2023-03-23 14:02:40 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6872,7 +6940,7 @@ category = Letter;
 },
 {
 glyphname = brm_num40;
-lastChange = "2023-03-23 14:02:53 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -6954,7 +7022,7 @@ category = Letter;
 },
 {
 glyphname = brm_num50;
-lastChange = "2023-03-23 14:03:10 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7035,7 +7103,7 @@ category = Letter;
 },
 {
 glyphname = brm_num60;
-lastChange = "2023-03-23 14:03:34 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7092,7 +7160,7 @@ category = Letter;
 },
 {
 glyphname = brm_num70;
-lastChange = "2023-03-23 14:04:08 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7170,7 +7238,7 @@ category = Letter;
 },
 {
 glyphname = brm_num80;
-lastChange = "2023-03-23 14:04:28 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7255,7 +7323,7 @@ category = Letter;
 },
 {
 glyphname = brm_num90;
-lastChange = "2023-03-23 14:04:44 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7356,7 +7424,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100;
-lastChange = "2023-03-23 14:04:58 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7443,7 +7511,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000;
-lastChange = "2023-03-23 14:05:10 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7531,7 +7599,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit0;
-lastChange = "2023-03-23 14:05:17 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7592,7 +7660,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit1;
-lastChange = "2023-03-23 14:05:28 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7655,7 +7723,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit2;
-lastChange = "2023-03-23 14:05:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7731,7 +7799,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit3;
-lastChange = "2023-03-23 14:05:50 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7822,7 +7890,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit4;
-lastChange = "2023-03-23 14:06:03 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -7917,7 +7985,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit5;
-lastChange = "2023-03-23 14:06:14 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -8016,7 +8084,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit6;
-lastChange = "2023-03-23 14:06:28 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -8094,7 +8162,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit7;
-lastChange = "2023-03-23 14:06:35 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -8175,7 +8243,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit8;
-lastChange = "2023-03-23 14:06:43 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -8242,7 +8310,7 @@ category = Letter;
 },
 {
 glyphname = brm_digit9;
-lastChange = "2023-03-23 14:06:50 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -8322,8 +8390,362 @@ unicode = 1106F;
 category = Letter;
 },
 {
+glyphname = brm_OldTamilVirama;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 505 OFFCURVE",
+"22 480 OFFCURVE",
+"61 480 CURVE SMOOTH",
+"100 480 OFFCURVE",
+"124 506 OFFCURVE",
+"124 548 CURVE SMOOTH",
+"124 591 OFFCURVE",
+"102 616 OFFCURVE",
+"61 616 CURVE SMOOTH",
+"20 616 OFFCURVE",
+"0 591 OFFCURVE",
+"0 548 CURVE SMOOTH"
+);
+}
+);
+width = 172;
+}
+);
+unicode = 11070;
+category = Mark;
+subCategory = Spacing;
+},
+{
+glyphname = brm_shortE;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor29;
+position = "{332, 786}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"98 -5 LINE",
+"180 -5 LINE",
+"624 380 LINE",
+"174 719 LINE",
+"98 719 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"180 619 LINE",
+"509 380 LINE",
+"180 95 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"334 300 OFFCURVE",
+"355 323 OFFCURVE",
+"355 362 CURVE SMOOTH",
+"355 401 OFFCURVE",
+"335 424 OFFCURVE",
+"297 424 CURVE SMOOTH",
+"260 424 OFFCURVE",
+"241 401 OFFCURVE",
+"241 362 CURVE SMOOTH",
+"241 323 OFFCURVE",
+"262 300 OFFCURVE",
+"297 300 CURVE SMOOTH"
+);
+}
+);
+width = 662;
+}
+);
+unicode = 11071;
+category = Letter;
+subCategory = Other;
+},
+{
+glyphname = brm_shortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor29;
+position = "{535, 786}";
+},
+{
+name = center;
+position = "{545, 478}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"48 632 OFFCURVE",
+"70 606 OFFCURVE",
+"109 606 CURVE SMOOTH",
+"149 606 OFFCURVE",
+"172 633 OFFCURVE",
+"172 674 CURVE SMOOTH",
+"172 718 OFFCURVE",
+"150 742 OFFCURVE",
+"109 742 CURVE SMOOTH",
+"69 742 OFFCURVE",
+"48 717 OFFCURVE",
+"48 674 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"223 714 LINE",
+"223 634 LINE",
+"379 634 LINE",
+"379 0 LINE",
+"732 0 LINE",
+"732 80 LINE",
+"468 80 LINE",
+"468 714 LINE"
+);
+}
+);
+width = 780;
+}
+);
+unicode = 11072;
+category = Letter;
+subCategory = Other;
+},
+{
+glyphname = brm_vowelShortE;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor33;
+position = "{-137, 786}";
+},
+{
+name = _ee_oo;
+position = "{9, 717}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"-215 634 LINE",
+"0 634 LINE",
+"0 714 LINE",
+"-215 714 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-369 631 OFFCURVE",
+"-347 606 OFFCURVE",
+"-308 606 CURVE SMOOTH",
+"-269 606 OFFCURVE",
+"-245 632 OFFCURVE",
+"-245 674 CURVE SMOOTH",
+"-245 717 OFFCURVE",
+"-267 742 OFFCURVE",
+"-308 742 CURVE SMOOTH",
+"-349 742 OFFCURVE",
+"-369 717 OFFCURVE",
+"-369 674 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 11073;
+category = Mark;
+subCategory = Nonspacing;
+},
+{
+glyphname = brm_vowelShortO;
+lastChange = "2023-06-27 13:13:40 +0000";
+layers = (
+{
+anchors = (
+{
+name = Anchor33;
+position = "{229, 786}";
+},
+{
+name = _ee_oo;
+position = "{219, 717}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 634 LINE",
+"205 634 LINE",
+"205 714 LINE",
+"0 714 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"221 634 LINE",
+"480 634 LINE",
+"480 714 LINE",
+"221 714 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"-154 631 OFFCURVE",
+"-132 606 OFFCURVE",
+"-93 606 CURVE SMOOTH",
+"-54 606 OFFCURVE",
+"-30 632 OFFCURVE",
+"-30 674 CURVE SMOOTH",
+"-30 717 OFFCURVE",
+"-52 742 OFFCURVE",
+"-93 742 CURVE SMOOTH",
+"-134 742 OFFCURVE",
+"-154 717 OFFCURVE",
+"-154 674 CURVE SMOOTH"
+);
+}
+);
+width = 0;
+}
+);
+unicode = 11074;
+category = Mark;
+subCategory = Nonspacing;
+},
+{
+glyphname = brm_OldTamilLLA;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = aa;
+position = "{595, 717}";
+},
+{
+name = ai;
+position = "{590, 591}";
+},
+{
+name = au;
+position = "{590, 593}";
+},
+{
+name = bottom;
+position = "{429, 0}";
+},
+{
+name = bottomleft;
+position = "{320, 80}";
+},
+{
+name = bottomright;
+position = "{478, 0}";
+},
+{
+name = center;
+position = "{693, 478}";
+},
+{
+name = ee_oo;
+position = "{590, 717}";
+},
+{
+name = top;
+position = "{590, 786}";
+},
+{
+name = topleft;
+position = "{595, 717}";
+},
+{
+name = viramatm;
+position = "{754, 480}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"587 -12 OFFCURVE",
+"635 77 OFFCURVE",
+"635 252 CURVE SMOOTH",
+"635 266 LINE",
+"654 272 OFFCURVE",
+"676 275 OFFCURVE",
+"701 275 CURVE SMOOTH",
+"788 275 OFFCURVE",
+"821 237 OFFCURVE",
+"821 146 CURVE SMOOTH",
+"821 0 LINE",
+"911 0 LINE",
+"911 163 LINE SMOOTH",
+"911 300 OFFCURVE",
+"842 359 OFFCURVE",
+"711 359 CURVE SMOOTH",
+"684 359 OFFCURVE",
+"659 355 OFFCURVE",
+"635 347 CURVE",
+"635 714 LINE",
+"545 714 LINE",
+"545 247 LINE SMOOTH",
+"545 130 OFFCURVE",
+"524 72 OFFCURVE",
+"428 72 CURVE SMOOTH",
+"327 72 OFFCURVE",
+"292 107 OFFCURVE",
+"291 255 CURVE",
+"49 255 LINE",
+"49 175 LINE",
+"205 175 LINE",
+"220 44 OFFCURVE",
+"288 -12 OFFCURVE",
+"421 -12 CURVE SMOOTH"
+);
+}
+);
+width = 989;
+}
+);
+unicode = 11075;
+category = Letter;
+subCategory = Other;
+},
+{
 glyphname = brm_GHU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8365,7 +8787,7 @@ category = Letter;
 },
 {
 glyphname = brm_GHUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8416,7 +8838,7 @@ category = Letter;
 },
 {
 glyphname = brm_NGU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8444,7 +8866,7 @@ category = Letter;
 },
 {
 glyphname = brm_NGUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8476,7 +8898,7 @@ category = Letter;
 },
 {
 glyphname = brm_CU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8520,7 +8942,7 @@ category = Letter;
 },
 {
 glyphname = brm_CUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8571,7 +8993,7 @@ category = Letter;
 },
 {
 glyphname = brm_CHU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8631,7 +9053,7 @@ category = Letter;
 },
 {
 glyphname = brm_CHUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8700,7 +9122,7 @@ category = Letter;
 },
 {
 glyphname = brm_JAA;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8757,7 +9179,7 @@ category = Letter;
 },
 {
 glyphname = brm_JO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8817,7 +9239,7 @@ category = Letter;
 },
 {
 glyphname = brm_JAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8886,7 +9308,7 @@ category = Letter;
 },
 {
 glyphname = brm_JU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8939,7 +9361,7 @@ category = Letter;
 },
 {
 glyphname = brm_JUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -8998,7 +9420,7 @@ category = Letter;
 },
 {
 glyphname = brm_JHO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9040,7 +9462,7 @@ category = Letter;
 },
 {
 glyphname = brm_JHAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9086,7 +9508,7 @@ category = Letter;
 },
 {
 glyphname = brm_NYO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9134,7 +9556,7 @@ category = Letter;
 },
 {
 glyphname = brm_NYAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9186,7 +9608,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9223,7 +9645,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9266,7 +9688,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9325,7 +9747,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9390,7 +9812,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9440,7 +9862,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9499,7 +9921,7 @@ category = Letter;
 },
 {
 glyphname = brm_DDHU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9555,7 +9977,7 @@ category = Letter;
 },
 {
 glyphname = brm_DDHUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9620,7 +10042,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9652,7 +10074,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9688,7 +10110,7 @@ category = Letter;
 },
 {
 glyphname = brm_THO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9764,7 +10186,7 @@ category = Letter;
 },
 {
 glyphname = brm_THAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9846,7 +10268,7 @@ category = Letter;
 },
 {
 glyphname = brm_THU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9913,7 +10335,7 @@ category = Letter;
 },
 {
 glyphname = brm_THUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -9989,7 +10411,7 @@ category = Letter;
 },
 {
 glyphname = brm_DHO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10033,7 +10455,7 @@ category = Letter;
 },
 {
 glyphname = brm_DHAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10081,7 +10503,7 @@ category = Letter;
 },
 {
 glyphname = brm_NU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10109,7 +10531,7 @@ category = Letter;
 },
 {
 glyphname = brm_NUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10141,7 +10563,7 @@ category = Letter;
 },
 {
 glyphname = brm_PU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10180,7 +10602,7 @@ category = Letter;
 },
 {
 glyphname = brm_PUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10228,7 +10650,7 @@ category = Letter;
 },
 {
 glyphname = brm_PHU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10277,7 +10699,7 @@ category = Letter;
 },
 {
 glyphname = brm_PHUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10335,7 +10757,7 @@ category = Letter;
 },
 {
 glyphname = brm_BO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10370,7 +10792,7 @@ category = Letter;
 },
 {
 glyphname = brm_BAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10409,7 +10831,7 @@ category = Letter;
 },
 {
 glyphname = brm_BU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10444,7 +10866,7 @@ category = Letter;
 },
 {
 glyphname = brm_BUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10483,7 +10905,7 @@ category = Letter;
 },
 {
 glyphname = brm_MO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10550,7 +10972,7 @@ category = Letter;
 },
 {
 glyphname = brm_MAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10623,7 +11045,7 @@ category = Letter;
 },
 {
 glyphname = brm_MU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10691,7 +11113,7 @@ category = Letter;
 },
 {
 glyphname = brm_MUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10768,7 +11190,7 @@ category = Letter;
 },
 {
 glyphname = brm_YU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10822,7 +11244,7 @@ category = Letter;
 },
 {
 glyphname = brm_YUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10885,7 +11307,7 @@ category = Letter;
 },
 {
 glyphname = brm_LU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10925,7 +11347,7 @@ category = Letter;
 },
 {
 glyphname = brm_LUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -10974,7 +11396,7 @@ category = Letter;
 },
 {
 glyphname = brm_VU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11027,7 +11449,7 @@ category = Letter;
 },
 {
 glyphname = brm_VUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11089,7 +11511,7 @@ category = Letter;
 },
 {
 glyphname = brm_SSU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11132,7 +11554,7 @@ category = Letter;
 },
 {
 glyphname = brm_SSUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11184,7 +11606,7 @@ category = Letter;
 },
 {
 glyphname = brm_SU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11239,7 +11661,7 @@ category = Letter;
 },
 {
 glyphname = brm_SUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11303,7 +11725,7 @@ category = Letter;
 },
 {
 glyphname = brm_HU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11342,7 +11764,7 @@ category = Letter;
 },
 {
 glyphname = brm_HUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11390,7 +11812,7 @@ category = Letter;
 },
 {
 glyphname = brm_LLU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11445,7 +11867,7 @@ category = Letter;
 },
 {
 glyphname = brm_LLUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11509,7 +11931,7 @@ category = Letter;
 },
 {
 glyphname = brm_LLLO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11576,7 +11998,7 @@ category = Letter;
 },
 {
 glyphname = brm_LLLAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11652,7 +12074,7 @@ category = Letter;
 },
 {
 glyphname = brm_RRO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11711,7 +12133,7 @@ category = Letter;
 },
 {
 glyphname = brm_RRAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11779,7 +12201,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNNO;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11823,7 +12245,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNNAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11874,7 +12296,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNNU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11916,7 +12338,7 @@ category = Letter;
 },
 {
 glyphname = brm_NNNUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -11962,7 +12384,7 @@ category = Letter;
 },
 {
 glyphname = candrabindu.alt;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -11999,7 +12421,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = u1107F;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -12256,7 +12678,7 @@ category = Letter;
 },
 {
 glyphname = brm_SVA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12375,7 +12797,7 @@ category = Letter;
 },
 {
 glyphname = brm_KSSA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12461,7 +12883,7 @@ category = Letter;
 },
 {
 glyphname = brm_JNYA;
-lastChange = "2023-03-23 14:09:38 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12569,7 +12991,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.2;
-lastChange = "2023-03-23 14:07:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12660,7 +13082,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.3;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12754,7 +13176,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.4;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12853,7 +13275,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.5;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -12960,7 +13382,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.6;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13091,7 +13513,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.7;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13206,7 +13628,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.8;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13319,7 +13741,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.9;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13427,7 +13849,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.10;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13557,7 +13979,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.20;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13680,7 +14102,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.30;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13791,7 +14213,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.40;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -13905,7 +14327,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.50;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14024,7 +14446,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.60;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14119,7 +14541,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.70;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14229,7 +14651,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.80;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14352,7 +14774,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.90;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14491,7 +14913,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.100;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14616,7 +15038,7 @@ category = Letter;
 },
 {
 glyphname = brm_num100.1000;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14742,7 +15164,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.2;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14831,7 +15253,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.3;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -14926,7 +15348,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.4;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15026,7 +15448,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.5;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15134,7 +15556,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.6;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15266,7 +15688,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.7;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15376,7 +15798,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.8;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15490,7 +15912,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.9;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15599,7 +16021,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.10;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15730,7 +16152,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.20;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15854,7 +16276,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.30;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -15967,7 +16389,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.40;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16082,7 +16504,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.50;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16202,7 +16624,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.60;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16298,7 +16720,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.70;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16409,7 +16831,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.80;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16533,7 +16955,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.90;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16673,7 +17095,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.100;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16799,7 +17221,7 @@ category = Letter;
 },
 {
 glyphname = brm_num1000.1000;
-lastChange = "2023-03-23 13:38:04 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -16926,7 +17348,7 @@ category = Letter;
 },
 {
 glyphname = uni25CC;
-lastChange = "2023-03-23 14:09:39 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -17258,7 +17680,7 @@ category = Letter;
 },
 {
 glyphname = u11003_11013;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17310,7 +17732,7 @@ category = Letter;
 },
 {
 glyphname = u11003_11014;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17376,7 +17798,7 @@ category = Letter;
 },
 {
 glyphname = u11004_11027;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17475,7 +17897,7 @@ category = Letter;
 },
 {
 glyphname = u11004_11028;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17590,7 +18012,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHEE;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17643,7 +18065,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHAI;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17702,7 +18124,7 @@ category = Letter;
 },
 {
 glyphname = brm_THEE;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17772,7 +18194,7 @@ category = Letter;
 },
 {
 glyphname = brm_THAI;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17848,7 +18270,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17901,7 +18323,7 @@ category = Letter;
 },
 {
 glyphname = brm_THR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -17971,7 +18393,7 @@ category = Letter;
 },
 {
 glyphname = brm_TTHRR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18030,7 +18452,7 @@ category = Letter;
 },
 {
 glyphname = brm_THRR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18106,7 +18528,7 @@ category = Letter;
 },
 {
 glyphname = brm_DAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18152,7 +18574,7 @@ category = Letter;
 },
 {
 glyphname = brm_DHU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18198,7 +18620,7 @@ category = Letter;
 },
 {
 glyphname = brm_DHUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18247,7 +18669,7 @@ category = Letter;
 },
 {
 glyphname = brm_BHAU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18290,7 +18712,7 @@ category = Letter;
 },
 {
 glyphname = brm_TRR;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18335,7 +18757,7 @@ category = Letter;
 },
 {
 glyphname = brm_TUU;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-28 12:29:14 +0000";
 layers = (
 {
 layerId = UUID0;
@@ -18379,8 +18801,672 @@ width = 818;
 category = Letter;
 },
 {
+glyphname = brm_DHAshortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"431 0 LINE",
+"650 0 OFFCURVE",
+"759 132 OFFCURVE",
+"759 358 CURVE SMOOTH",
+"759 469 OFFCURVE",
+"729 559 OFFCURVE",
+"653 634 CURVE",
+"809 634 LINE",
+"809 714 LINE",
+"202 714 LINE",
+"202 634 LINE",
+"327 634 LINE",
+"327 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"416 634 LINE",
+"580 634 OFFCURVE",
+"664 525 OFFCURVE",
+"664 357 CURVE SMOOTH",
+"664 179 OFFCURVE",
+"578 80 OFFCURVE",
+"418 80 CURVE SMOOTH",
+"416 80 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 631 OFFCURVE",
+"70 606 OFFCURVE",
+"109 606 CURVE SMOOTH",
+"148 606 OFFCURVE",
+"172 632 OFFCURVE",
+"172 674 CURVE SMOOTH",
+"172 717 OFFCURVE",
+"150 742 OFFCURVE",
+"109 742 CURVE SMOOTH",
+"68 742 OFFCURVE",
+"48 717 OFFCURVE",
+"48 674 CURVE SMOOTH"
+);
+}
+);
+width = 858;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_LLLAshortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"202 487 LINE",
+"337 487 LINE",
+"350 409 OFFCURVE",
+"418 349 OFFCURVE",
+"494 333 CURVE",
+"494 259 LINE",
+"275 259 LINE",
+"275 0 LINE",
+"365 0 LINE",
+"365 179 LINE",
+"584 179 LINE",
+"584 333 LINE",
+"662 349 OFFCURVE",
+"725 410 OFFCURVE",
+"741 487 CURVE",
+"930 487 LINE",
+"930 567 LINE",
+"740 567 LINE",
+"722 654 OFFCURVE",
+"639 724 OFFCURVE",
+"539 724 CURVE SMOOTH",
+"442 724 OFFCURVE",
+"356 657 OFFCURVE",
+"338 567 CURVE",
+"202 567 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"419 579 OFFCURVE",
+"450 624 OFFCURVE",
+"497 640 CURVE",
+"497 412 LINE",
+"448 429 OFFCURVE",
+"419 473 OFFCURVE",
+"419 525 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"659 473 OFFCURVE",
+"630 429 OFFCURVE",
+"581 412 CURVE",
+"581 640 LINE",
+"628 624 OFFCURVE",
+"659 580 OFFCURVE",
+"659 525 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 484 OFFCURVE",
+"70 459 OFFCURVE",
+"109 459 CURVE SMOOTH",
+"148 459 OFFCURVE",
+"172 485 OFFCURVE",
+"172 527 CURVE SMOOTH",
+"172 570 OFFCURVE",
+"150 595 OFFCURVE",
+"109 595 CURVE SMOOTH",
+"68 595 OFFCURVE",
+"48 570 OFFCURVE",
+"48 527 CURVE SMOOTH"
+);
+}
+);
+width = 979;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_MAshortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"779 674 LINE",
+"779 550 OFFCURVE",
+"691 498 OFFCURVE",
+"598 442 CURVE",
+"507 496 OFFCURVE",
+"417 550 OFFCURVE",
+"417 674 CURVE SMOOTH",
+"417 714 LINE",
+"202 714 LINE",
+"202 634 LINE",
+"329 634 LINE",
+"343 520 OFFCURVE",
+"410 458 OFFCURVE",
+"521 394 CURVE",
+"426 333 OFFCURVE",
+"385 263 OFFCURVE",
+"385 174 CURVE SMOOTH",
+"385 57 OFFCURVE",
+"461 -12 OFFCURVE",
+"596 -12 CURVE SMOOTH",
+"735 -12 OFFCURVE",
+"811 57 OFFCURVE",
+"811 174 CURVE SMOOTH",
+"811 262 OFFCURVE",
+"772 332 OFFCURVE",
+"676 395 CURVE",
+"809 478 OFFCURVE",
+"855 534 OFFCURVE",
+"866 634 CURVE",
+"1048 634 LINE",
+"1048 714 LINE",
+"779 714 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"679 299 OFFCURVE",
+"716 246 OFFCURVE",
+"716 178 CURVE SMOOTH",
+"716 106 OFFCURVE",
+"672 72 OFFCURVE",
+"596 72 CURVE SMOOTH",
+"524 72 OFFCURVE",
+"480 107 OFFCURVE",
+"480 178 CURVE SMOOTH",
+"480 246 OFFCURVE",
+"519 299 OFFCURVE",
+"599 350 CURVE"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 631 OFFCURVE",
+"70 606 OFFCURVE",
+"109 606 CURVE SMOOTH",
+"148 606 OFFCURVE",
+"172 632 OFFCURVE",
+"172 674 CURVE SMOOTH",
+"172 717 OFFCURVE",
+"150 742 OFFCURVE",
+"109 742 CURVE SMOOTH",
+"68 742 OFFCURVE",
+"48 717 OFFCURVE",
+"48 674 CURVE SMOOTH"
+);
+}
+);
+width = 1082;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_NNNAshortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"202 482 LINE",
+"333 482 LINE",
+"333 79 LINE",
+"218 79 LINE",
+"218 0 LINE",
+"718 0 LINE",
+"718 79 LINE",
+"423 79 LINE",
+"423 497 LINE SMOOTH",
+"423 604 OFFCURVE",
+"450 642 OFFCURVE",
+"528 642 CURVE SMOOTH",
+"604 642 OFFCURVE",
+"628 605 OFFCURVE",
+"628 496 CURVE SMOOTH",
+"628 482 LINE",
+"894 482 LINE",
+"894 562 LINE",
+"714 562 LINE",
+"698 677 OFFCURVE",
+"638 726 OFFCURVE",
+"522 726 CURVE SMOOTH",
+"407 726 OFFCURVE",
+"353 677 OFFCURVE",
+"337 562 CURVE",
+"202 562 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 479 OFFCURVE",
+"70 454 OFFCURVE",
+"109 454 CURVE SMOOTH",
+"148 454 OFFCURVE",
+"172 480 OFFCURVE",
+"172 522 CURVE SMOOTH",
+"172 565 OFFCURVE",
+"150 590 OFFCURVE",
+"109 590 CURVE SMOOTH",
+"68 590 OFFCURVE",
+"48 565 OFFCURVE",
+"48 522 CURVE SMOOTH"
+);
+}
+);
+width = 943;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_NYAshortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"413 0 LINE",
+"413 413 LINE",
+"432 419 OFFCURVE",
+"454 422 OFFCURVE",
+"478 422 CURVE SMOOTH",
+"563 422 OFFCURVE",
+"598 386 OFFCURVE",
+"598 292 CURVE SMOOTH",
+"598 170 LINE",
+"688 170 LINE",
+"688 310 LINE SMOOTH",
+"688 446 OFFCURVE",
+"619 505 OFFCURVE",
+"489 505 CURVE SMOOTH",
+"463 505 OFFCURVE",
+"438 501 OFFCURVE",
+"413 494 CURVE",
+"413 549 LINE",
+"637 549 LINE",
+"637 629 LINE",
+"413 629 LINE",
+"413 714 LINE",
+"168 714 LINE",
+"168 634 LINE",
+"324 634 LINE",
+"324 549 LINE",
+"202 549 LINE",
+"202 469 LINE",
+"324 469 LINE",
+"324 0 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 466 OFFCURVE",
+"70 441 OFFCURVE",
+"109 441 CURVE SMOOTH",
+"148 441 OFFCURVE",
+"172 467 OFFCURVE",
+"172 509 CURVE SMOOTH",
+"172 552 OFFCURVE",
+"150 577 OFFCURVE",
+"109 577 CURVE SMOOTH",
+"68 577 OFFCURVE",
+"48 552 OFFCURVE",
+"48 509 CURVE SMOOTH"
+);
+}
+);
+width = 766;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_RRAVirama;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+anchors = (
+{
+name = aa;
+position = "{292, 717}";
+},
+{
+name = ai;
+position = "{253, 576}";
+},
+{
+name = au;
+position = "{0, 0}";
+},
+{
+name = bottom;
+position = "{244, 0}";
+},
+{
+name = bottomleft;
+position = "{146, 0}";
+},
+{
+name = bottomright;
+position = "{370, 0}";
+},
+{
+name = ee_oo;
+position = "{224, 634}";
+},
+{
+name = top;
+position = "{322, 786}";
+},
+{
+name = topleft;
+position = "{292, 717}";
+}
+);
+background = {
+anchors = (
+{
+name = aa;
+position = "{292, 717}";
+},
+{
+name = ai;
+position = "{253, 576}";
+},
+{
+name = au;
+position = "{0, 0}";
+},
+{
+name = bottom;
+position = "{244, 0}";
+},
+{
+name = bottomleft;
+position = "{146, 0}";
+},
+{
+name = bottomright;
+position = "{370, 0}";
+},
+{
+name = ee_oo;
+position = "{224, 634}";
+},
+{
+name = top;
+position = "{322, 786}";
+},
+{
+name = topleft;
+position = "{292, 717}";
+}
+);
+components = (
+{
+name = brm_OldTamilVirama;
+transform = "{1, 0, 0, 1, 291, -17}";
+}
+);
+paths = (
+{
+closed = 1;
+nodes = (
+"153 0 LINE",
+"153 32 LINE SMOOTH",
+"153 119 OFFCURVE",
+"184 156 OFFCURVE",
+"273 156 CURVE SMOOTH",
+"297 156 OFFCURVE",
+"319 153 OFFCURVE",
+"338 147 CURVE",
+"338 0 LINE",
+"428 0 LINE",
+"428 423 LINE",
+"344 423 LINE SMOOTH",
+"277 423 OFFCURVE",
+"243 452 OFFCURVE",
+"243 528 CURVE SMOOTH",
+"243 607 OFFCURVE",
+"273 634 OFFCURVE",
+"344 634 CURVE SMOOTH",
+"428 634 LINE",
+"428 714 LINE",
+"342 714 LINE SMOOTH",
+"222 714 OFFCURVE",
+"153 666 OFFCURVE",
+"153 529 CURVE SMOOTH",
+"153 391 OFFCURVE",
+"219 344 OFFCURVE",
+"338 343 CURVE",
+"338 228 LINE",
+"313 236 OFFCURVE",
+"288 240 OFFCURVE",
+"263 240 CURVE SMOOTH",
+"126 240 OFFCURVE",
+"63 178 OFFCURVE",
+"63 49 CURVE SMOOTH",
+"63 0 LINE"
+);
+}
+);
+};
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"291 493 OFFCURVE",
+"313 468 OFFCURVE",
+"352 468 CURVE SMOOTH",
+"391 468 OFFCURVE",
+"415 494 OFFCURVE",
+"415 536 CURVE SMOOTH",
+"415 579 OFFCURVE",
+"393 604 OFFCURVE",
+"352 604 CURVE SMOOTH",
+"311 604 OFFCURVE",
+"291 579 OFFCURVE",
+"291 536 CURVE SMOOTH"
+);
+},
+{
+closed = 1;
+nodes = (
+"153 0 LINE",
+"153 122 LINE SMOOTH",
+"153 209 OFFCURVE",
+"184 246 OFFCURVE",
+"273 246 CURVE SMOOTH",
+"297 246 OFFCURVE",
+"319 243 OFFCURVE",
+"338 237 CURVE",
+"338 0 LINE",
+"428 0 LINE",
+"428 439 LINE",
+"344 439 LINE SMOOTH",
+"285 439 OFFCURVE",
+"243 469 OFFCURVE",
+"243 534 CURVE SMOOTH",
+"243 603 OFFCURVE",
+"273 634 OFFCURVE",
+"344 634 CURVE SMOOTH",
+"428 634 LINE",
+"428 714 LINE",
+"342 714 LINE SMOOTH",
+"222 714 OFFCURVE",
+"153 652 OFFCURVE",
+"153 534 CURVE SMOOTH",
+"153 427 OFFCURVE",
+"219 360 OFFCURVE",
+"338 359 CURVE",
+"338 318 LINE",
+"313 326 OFFCURVE",
+"288 330 OFFCURVE",
+"263 330 CURVE SMOOTH",
+"126 330 OFFCURVE",
+"63 268 OFFCURVE",
+"63 139 CURVE SMOOTH",
+"63 0 LINE"
+);
+}
+);
+width = 525;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_RRAshortO;
+lastChange = "2023-06-05 10:27:16 +0000";
+layers = (
+{
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"202 498 LINE",
+"304 498 LINE",
+"317 413 OFFCURVE",
+"381 360 OFFCURVE",
+"486 359 CURVE",
+"486 318 LINE",
+"461 326 OFFCURVE",
+"436 330 OFFCURVE",
+"411 330 CURVE SMOOTH",
+"272 330 OFFCURVE",
+"211 268 OFFCURVE",
+"211 139 CURVE SMOOTH",
+"211 0 LINE",
+"301 0 LINE",
+"301 122 LINE SMOOTH",
+"301 211 OFFCURVE",
+"335 246 OFFCURVE",
+"421 246 CURVE SMOOTH",
+"446 246 OFFCURVE",
+"467 243 OFFCURVE",
+"486 237 CURVE",
+"486 0 LINE",
+"576 0 LINE",
+"576 439 LINE",
+"492 439 LINE SMOOTH",
+"440 439 OFFCURVE",
+"409 461 OFFCURVE",
+"396 498 CURVE",
+"576 498 LINE",
+"576 578 LINE",
+"396 578 LINE",
+"408 615 OFFCURVE",
+"437 634 OFFCURVE",
+"492 634 CURVE SMOOTH",
+"576 634 LINE",
+"576 714 LINE",
+"490 714 LINE SMOOTH",
+"385 714 OFFCURVE",
+"320 667 OFFCURVE",
+"305 578 CURVE",
+"202 578 LINE"
+);
+},
+{
+closed = 1;
+nodes = (
+"48 495 OFFCURVE",
+"70 470 OFFCURVE",
+"109 470 CURVE SMOOTH",
+"148 470 OFFCURVE",
+"172 496 OFFCURVE",
+"172 538 CURVE SMOOTH",
+"172 581 OFFCURVE",
+"150 606 OFFCURVE",
+"109 606 CURVE SMOOTH",
+"68 606 OFFCURVE",
+"48 581 OFFCURVE",
+"48 538 CURVE SMOOTH"
+);
+}
+);
+width = 673;
+}
+);
+category = Letter;
+},
+{
+glyphname = brm_OldTamilVirama.alt;
+lastChange = "2023-06-28 08:18:26 +0000";
+layers = (
+{
+anchors = (
+{
+name = _viramatm;
+position = "{61, 480}";
+}
+);
+layerId = UUID0;
+paths = (
+{
+closed = 1;
+nodes = (
+"0 505 OFFCURVE",
+"22 480 OFFCURVE",
+"61 480 CURVE SMOOTH",
+"100 480 OFFCURVE",
+"124 506 OFFCURVE",
+"124 548 CURVE SMOOTH",
+"124 591 OFFCURVE",
+"102 616 OFFCURVE",
+"61 616 CURVE SMOOTH",
+"20 616 OFFCURVE",
+"0 591 OFFCURVE",
+"0 548 CURVE SMOOTH"
+);
+}
+);
+width = 172;
+}
+);
+category = Mark;
+subCategory = Nonspacing;
+},
+{
 glyphname = brm_vowelU.alt;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18409,7 +19495,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelUU.alt;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18456,7 +19542,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_vowelUU.alt2;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18503,7 +19589,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_R.alt;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18532,7 +19618,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_R.alt2;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18561,7 +19647,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_RR.alt;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18608,7 +19694,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_RR.alt2;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18646,7 +19732,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = brm_VOCALIC_RR.alt3;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18693,7 +19779,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = vowelU_vert;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (
@@ -18722,7 +19808,7 @@ subCategory = Nonspacing;
 },
 {
 glyphname = vowelUU_vert;
-lastChange = "2019-09-20 20:39:33 +0000";
+lastChange = "2023-06-05 10:27:16 +0000";
 layers = (
 {
 anchors = (


### PR DESCRIPTION
– Added them in necessary classes

– Added glyphs brm_OldTamilVirama (U+11070) and brm_OldTamilVirama.alt (non-spacing mark) – Added anchor ‘viramatm’ to glyphs where mark needs to be non-spacing [brm_KA brm_PA brm_YA brm_OldTamilLLA SA brm_NYA brm_NGA brm_TTA brm_NNA]
- Added alternate glyph and gsub rule for ‘brm_RRAVirama’

– Added glyphs brm_OldTamilLLA (U+11075) and edited brm_LLA (U+11034). Please note: In version 2.003, BRAHMI LETTER LLA is drawn like BRAHMI LETTER OLD TAMIL LLA instead of its form as per the unicode chart. So, we copied the form from brm_LLA to brm_OldTamilLLA and redrew brm_LLA, to match their respective forms with the Unicode chart.
- Edited classes to incorporate the change in LLA and OldTamilLLA

– Added glyphs brm_vowelShortE (U+11073), brm_vowelShortO (U+11074) – Added combining forms with Tamil Brahmi characters, ‘brm_DHAshortO’, ‘brm_LLLAshortO’, ‘brm_MAshortO’, ‘brm_NNNAshortO’, ‘brm_NYAshortO’, ‘brm_RRAshortO’. – Added anchors and added/edited opentype features to avoid clashing of matras.

- Edited position of anchor ai in brm_NYA